### PR TITLE
Fix navigation shell, drawer cleanup, and AppSnackBar migration

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -252,6 +252,8 @@ function selectLanguageForUser(preferredLanguage) {
 exports.sendDailyDevotionalNotification = onSchedule({
   schedule: "0 * * * *",
   timeZone: "UTC",
+  timeoutSeconds: 540,
+  memory: "512MiB",
 }, async (context) => {
   logger.info("Notifications: Execution started.", {structuredData: true});
 

--- a/lib/pages/backup_settings_page.dart
+++ b/lib/pages/backup_settings_page.dart
@@ -19,6 +19,7 @@ import '../services/backup/i_google_drive_backup_service.dart';
 import '../services/service_locator.dart';
 import '../widgets/backup_configuration_sheet.dart';
 import 'package:devocional_nuevo/utils/constants/constants.dart';
+import 'package:devocional_nuevo/widgets/app_snack_bar.dart';
 
 List<({IconData icon, String label, int count})> _summaryItems(
   BackupContentSummary summary,
@@ -149,15 +150,13 @@ class _BackupSettingsViewState extends State<_BackupSettingsView> {
               );
             } else if (state is BackupCreated) {
               debugPrint('✅ [DEBUG] BackupCreated recibido');
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text('backup.created_successfully'.tr()),
-                  backgroundColor: colorScheme.primary,
-                ),
+              AppSnackBar.show(
+                context,
+                'backup.created_successfully'.tr(),
+                type: AppSnackBarType.tip,
               );
             } else if (state is BackupRestored) {
               debugPrint('✅ [DEBUG] BackupRestored recibido');
-              final messenger = ScaffoldMessenger.of(context);
               if (state.restoredVersion != null &&
                   state.restoredVersion!.isNotEmpty) {
                 final provider = context.read<DevocionalProvider>();
@@ -168,11 +167,11 @@ class _BackupSettingsViewState extends State<_BackupSettingsView> {
                   );
                 }
               }
-              messenger.showSnackBar(
-                SnackBar(
-                  content: Text('backup.restored_successfully'.tr()),
-                  backgroundColor: colorScheme.primary,
-                ),
+              if (!context.mounted) return;
+              AppSnackBar.show(
+                context,
+                'backup.restored_successfully'.tr(),
+                type: AppSnackBarType.tip,
               );
             } else if (state is BackupSuccess && !_successDialogShown) {
               debugPrint('✅ [DEBUG] BackupSuccess recibido — mostrando shield');

--- a/lib/pages/bible_reader_page.dart
+++ b/lib/pages/bible_reader_page.dart
@@ -16,6 +16,7 @@ import 'package:devocional_nuevo/services/tts/voice_settings_service.dart';
 import 'package:devocional_nuevo/utils/constants/bubble_constants.dart';
 import 'package:devocional_nuevo/utils/constants/constants.dart';
 import 'package:devocional_nuevo/utils/copyright_utils.dart';
+import 'package:devocional_nuevo/widgets/app_snack_bar.dart';
 import 'package:devocional_nuevo/widgets/bible/bible_book_selector_dialog.dart';
 import 'package:devocional_nuevo/widgets/bible/bible_chapter_grid_selector.dart';
 import 'package:devocional_nuevo/widgets/bible/bible_reader_action_modal.dart';
@@ -421,17 +422,7 @@ class _BibleReaderPageState extends State<BibleReaderPage> {
     Clipboard.setData(ClipboardData(text: text));
     Navigator.pop(modalContext);
     _controller.clearSelectedVerses();
-    final colorScheme = Theme.of(context).colorScheme;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(
-          'bible.copied_to_clipboard'.tr(),
-          style: TextStyle(color: colorScheme.onSecondary),
-        ),
-        backgroundColor: colorScheme.secondary,
-        duration: const Duration(seconds: 2),
-      ),
-    );
+    AppSnackBar.show(context, 'bible.copied_to_clipboard'.tr());
   }
 
   void _saveSelectedVerses(BuildContext modalContext) async {
@@ -448,20 +439,7 @@ class _BibleReaderPageState extends State<BibleReaderPage> {
     }
     _controller.clearSelectedVerses();
 
-    // Capture widget's context-dependent values immediately after mounted check
-    final scaffoldMessenger = ScaffoldMessenger.of(context);
-    final colorScheme = Theme.of(context).colorScheme;
-
-    scaffoldMessenger.showSnackBar(
-      SnackBar(
-        content: Text(
-          'bible.save_marked_verses'.tr(),
-          style: TextStyle(color: colorScheme.onSecondary),
-        ),
-        backgroundColor: colorScheme.secondary,
-        duration: const Duration(seconds: 2),
-      ),
-    );
+    AppSnackBar.show(context, 'bible.save_marked_verses'.tr());
   }
 
   void _deleteSelectedVerses(BuildContext modalContext) async {
@@ -479,20 +457,7 @@ class _BibleReaderPageState extends State<BibleReaderPage> {
     }
     _controller.clearSelectedVerses();
 
-    // Capture widget's context-dependent values immediately after mounted check
-    final scaffoldMessenger = ScaffoldMessenger.of(context);
-    final colorScheme = Theme.of(context).colorScheme;
-
-    scaffoldMessenger.showSnackBar(
-      SnackBar(
-        content: Text(
-          'bible.deleted_marked_verses'.tr(),
-          style: TextStyle(color: colorScheme.onSecondary),
-        ),
-        backgroundColor: colorScheme.secondary,
-        duration: const Duration(seconds: 2),
-      ),
-    );
+    AppSnackBar.show(context, 'bible.deleted_marked_verses'.tr());
   }
 
   // Helper para prefijos de capítulo y versículo según idioma
@@ -817,21 +782,13 @@ class _BibleReaderPageState extends State<BibleReaderPage> {
                       ),
                       tooltip: 'bible.select_version'.tr(),
                       onSelected: (version) async {
-                        final scaffoldMessenger = ScaffoldMessenger.of(context);
-                        final colorScheme = Theme.of(context).colorScheme;
                         await _controller.switchVersion(version);
-                        if (!mounted) return;
-                        scaffoldMessenger.showSnackBar(
-                          SnackBar(
-                            content: Text(
-                              'bible.loading_version'.tr({
-                                'version': version.name,
-                              }),
-                              style: TextStyle(color: colorScheme.onSecondary),
-                            ),
-                            backgroundColor: colorScheme.secondary,
-                            duration: const Duration(seconds: 1),
-                          ),
+                        if (!context.mounted) return;
+                        AppSnackBar.show(
+                          context,
+                          'bible.loading_version'.tr({
+                            'version': version.name,
+                          }),
                         );
                       },
                       itemBuilder: (context) => state.availableVersions.map((

--- a/lib/pages/devocionales_page.dart
+++ b/lib/pages/devocionales_page.dart
@@ -29,6 +29,7 @@ import 'package:devocional_nuevo/widgets/add_prayer_modal.dart';
 import 'package:devocional_nuevo/widgets/add_testimony_modal.dart';
 import 'package:devocional_nuevo/widgets/add_thanksgiving_modal.dart';
 import 'package:devocional_nuevo/widgets/app_bottom_nav_bar.dart';
+import 'package:devocional_nuevo/widgets/app_snack_bar.dart';
 import 'package:devocional_nuevo/widgets/devocionales/app_bar_constants.dart';
 import 'package:devocional_nuevo/widgets/devocionales/devocional_tts_miniplayer_presenter.dart';
 import 'package:devocional_nuevo/widgets/devocionales/devocionales_content_widget.dart';
@@ -687,18 +688,11 @@ class _DevocionalesPageState extends State<DevocionalesPage>
 
   void _showFavoritesFeedback(bool wasAdded) {
     if (!mounted) return;
-    final colorScheme = Theme.of(context).colorScheme;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(
-          wasAdded
-              ? 'devotionals_page.added_to_favorites'.tr()
-              : 'devotionals_page.removed_from_favorites'.tr(),
-          style: TextStyle(color: colorScheme.onSecondary),
-        ),
-        duration: const Duration(seconds: 2),
-        backgroundColor: colorScheme.secondary,
-      ),
+    AppSnackBar.show(
+      context,
+      wasAdded
+          ? 'devotionals_page.added_to_favorites'.tr()
+          : 'devotionals_page.removed_from_favorites'.tr(),
     );
   }
 

--- a/lib/pages/devocionales_page.dart
+++ b/lib/pages/devocionales_page.dart
@@ -13,7 +13,6 @@ import 'package:devocional_nuevo/helpers/devocional_navigation_helper.dart';
 import 'package:devocional_nuevo/main.dart';
 import 'package:devocional_nuevo/models/devocional_model.dart';
 import 'package:devocional_nuevo/pages/app_navigation_shell.dart';
-import 'package:devocional_nuevo/pages/progress_page.dart';
 import 'package:devocional_nuevo/providers/devocional_provider.dart';
 import 'package:devocional_nuevo/repositories/devocional_repository.dart';
 import 'package:devocional_nuevo/repositories/navigation_repository_impl.dart';
@@ -972,12 +971,8 @@ class _DevocionalesPageState extends State<DevocionalesPage>
                                   fontSize: _fontSizeController.fontSize,
                                   scrollController: _scrollController,
                                   onStreakBadgeTap: () {
-                                    Navigator.push(
-                                      context,
-                                      MaterialPageRoute(
-                                        builder: (context) =>
-                                            const ProgressPage(),
-                                      ),
+                                    AppNavigationShell.selectTab(
+                                      AppTab.progress,
                                     );
                                   },
                                   currentStreak: _currentStreak,

--- a/lib/pages/discovery_bible_studies/discovery_list_page.dart
+++ b/lib/pages/discovery_bible_studies/discovery_list_page.dart
@@ -15,6 +15,7 @@ import 'package:devocional_nuevo/providers/devocional_provider.dart';
 import 'package:devocional_nuevo/services/i_analytics_service.dart';
 import 'package:devocional_nuevo/services/service_locator.dart';
 import 'package:devocional_nuevo/utils/discovery_share_helper.dart';
+import 'package:devocional_nuevo/widgets/app_snack_bar.dart';
 import 'package:devocional_nuevo/widgets/devocionales/app_bar_constants.dart';
 import 'package:devocional_nuevo/widgets/discovery_actions_bar.dart';
 import 'package:devocional_nuevo/widgets/discovery_card_premium.dart';
@@ -533,32 +534,11 @@ class _DiscoveryListPageState extends State<DiscoveryListPage>
 
   void _showFeedbackSnackBar(String message, {bool useIcon = false}) {
     if (!mounted) return;
-    final colorScheme = Theme.of(context).colorScheme;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Row(
-          children: [
-            if (useIcon) ...[
-              const Icon(
-                Icons.verified_rounded,
-                color: Colors.greenAccent,
-                size: 20,
-              ),
-              const SizedBox(width: 12),
-            ],
-            Expanded(
-              child: Text(
-                message,
-                style: TextStyle(color: colorScheme.onSecondary),
-              ),
-            ),
-          ],
-        ),
-        duration: const Duration(seconds: 2),
-        backgroundColor: colorScheme.secondary,
-        behavior: SnackBarBehavior.floating,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-      ),
+    AppSnackBar.show(
+      context,
+      message,
+      icon: useIcon ? Icons.verified_rounded : null,
+      iconColor: Colors.greenAccent,
     );
   }
 

--- a/lib/pages/favorite_devocional_detail_page.dart
+++ b/lib/pages/favorite_devocional_detail_page.dart
@@ -12,6 +12,7 @@ import 'package:devocional_nuevo/services/supporter_pet_service.dart';
 import 'package:devocional_nuevo/utils/devotional_share_helper.dart';
 import 'package:devocional_nuevo/utils/localized_date_formatter.dart';
 import 'package:devocional_nuevo/widgets/app_bottom_nav_bar.dart';
+import 'package:devocional_nuevo/widgets/app_snack_bar.dart';
 import 'package:devocional_nuevo/widgets/devocionales/app_bar_constants.dart';
 import 'package:devocional_nuevo/widgets/devocionales/devocionales_content_widget.dart';
 import 'package:flutter/material.dart';
@@ -41,18 +42,11 @@ class _FavoriteDevocionalDetailPageState
 
   void _showFavoriteFeedback(bool wasAdded) {
     if (!mounted) return;
-    final colorScheme = Theme.of(context).colorScheme;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(
-          wasAdded
-              ? 'devotionals_page.added_to_favorites'.tr()
-              : 'devotionals_page.removed_from_favorites'.tr(),
-          style: TextStyle(color: colorScheme.onSecondary),
-        ),
-        duration: const Duration(seconds: 2),
-        backgroundColor: colorScheme.secondary,
-      ),
+    AppSnackBar.show(
+      context,
+      wasAdded
+          ? 'devotionals_page.added_to_favorites'.tr()
+          : 'devotionals_page.removed_from_favorites'.tr(),
     );
   }
 

--- a/lib/pages/notification_config_page.dart
+++ b/lib/pages/notification_config_page.dart
@@ -8,6 +8,7 @@ import 'package:devocional_nuevo/blocs/theme/theme_state.dart';
 import 'package:devocional_nuevo/extensions/string_extensions.dart';
 import 'package:devocional_nuevo/services/notification_service.dart';
 import 'package:devocional_nuevo/services/service_locator.dart';
+import 'package:devocional_nuevo/widgets/app_snack_bar.dart';
 import 'package:devocional_nuevo/widgets/devocionales/app_bar_constants.dart';
 // NEW IMPORTS for Firebase
 import 'package:firebase_auth/firebase_auth.dart';
@@ -232,22 +233,11 @@ class _NotificationConfigPageState extends State<NotificationConfigPage> {
       await _notificationService.setNotificationsEnabled(enabled);
 
       if (!mounted) return;
-      final messenger = ScaffoldMessenger.of(context);
-      // ACCIÓN: Ajuste del SnackBar para usar colorScheme.secondary y onSecondary
-      final ColorScheme colorScheme = Theme.of(
+      AppSnackBar.show(
         context,
-      ).colorScheme; // Obtener colorScheme
-      messenger.showSnackBar(
-        SnackBar(
-          backgroundColor: colorScheme.secondary,
-          content: Text(
-            _notificationsEnabled
-                ? 'notifications_config_page.notifications_enabled'.tr()
-                : 'notifications_config_page.notifications_disabled'.tr(),
-            // Usando _notificationsEnabled
-            style: TextStyle(color: colorScheme.onSecondary),
-          ),
-        ),
+        _notificationsEnabled
+            ? 'notifications_config_page.notifications_enabled'.tr()
+            : 'notifications_config_page.notifications_disabled'.tr(),
       );
     } catch (e) {
       developer.log(
@@ -316,20 +306,9 @@ class _NotificationConfigPageState extends State<NotificationConfigPage> {
         name: 'NotificationConfigPage',
       );
       if (mounted) {
-        final messenger = ScaffoldMessenger.of(context);
-        // ACCIÓN: Ajuste del SnackBar para usar colorScheme.secondary y onSecondary
-        final ColorScheme colorScheme = Theme.of(
+        AppSnackBar.show(
           context,
-        ).colorScheme; // Obtener colorScheme
-        messenger.showSnackBar(
-          SnackBar(
-            backgroundColor: colorScheme.secondary,
-            content: Text(
-              'notifications_config_page.time_not_changed'
-                  .tr(), // MENSAJE SI HORA NO CAMBIA
-              style: TextStyle(color: colorScheme.onSecondary),
-            ),
-          ),
+          'notifications_config_page.time_not_changed'.tr(),
         );
       }
       return;
@@ -358,19 +337,9 @@ class _NotificationConfigPageState extends State<NotificationConfigPage> {
         _selectedTime = _newlySelectedTime!; // Actualiza la hora principal
         _newlySelectedTime = null; // Resetea la hora nueva después de guardar
       });
-      final messenger = ScaffoldMessenger.of(context);
-      // ACCIÓN: Ajuste del SnackBar para usar colorScheme.secondary y onSecondary
-      final ColorScheme colorScheme = Theme.of(
+      AppSnackBar.show(
         context,
-      ).colorScheme; // Obtener colorScheme
-      messenger.showSnackBar(
-        SnackBar(
-          backgroundColor: colorScheme.secondary,
-          content: Text(
-            '${'notifications_config_page.notification_set'.tr()} $timeString',
-            style: TextStyle(color: colorScheme.onSecondary),
-          ),
-        ),
+        '${'notifications_config_page.notification_set'.tr()} $timeString',
       );
     } catch (e) {
       developer.log(

--- a/lib/pages/progress_page.dart
+++ b/lib/pages/progress_page.dart
@@ -13,6 +13,7 @@ import '../models/spiritual_stats_model.dart';
 import '../pages/favorites_page.dart';
 import '../providers/devocional_provider.dart';
 import '../services/spiritual_stats_service.dart';
+import '../widgets/app_snack_bar.dart';
 
 class ProgressPage extends StatefulWidget {
   const ProgressPage({super.key});
@@ -84,12 +85,9 @@ class _ProgressPageState extends State<ProgressPage>
       });
 
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(
-              'progress.error_loading_stats'.tr({'error': e.toString()}),
-            ),
-          ),
+        AppSnackBar.show(
+          context,
+          'progress.error_loading_stats'.tr({'error': e.toString()}),
         );
       }
     }

--- a/lib/pages/progress_page.dart
+++ b/lib/pages/progress_page.dart
@@ -272,7 +272,7 @@ class _ProgressPageState extends State<ProgressPage>
   Widget _buildContent() {
     return SingleChildScrollView(
       physics: const AlwaysScrollableScrollPhysics(),
-      padding: const EdgeInsets.all(16.0),
+      padding: const EdgeInsets.fromLTRB(16.0, 16.0, 16.0, 76.0),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/lib/pages/progress_page.dart
+++ b/lib/pages/progress_page.dart
@@ -203,21 +203,7 @@ class _ProgressPageState extends State<ProgressPage>
       value: themeState.systemUiOverlayStyle,
       child: Scaffold(
         appBar: AppBar(
-          leading: IconButton(
-            icon: Transform(
-              alignment: Alignment.center,
-              transform: Matrix4.rotationY(3.14159),
-              child: Icon(
-                Icons.exit_to_app,
-                color: Theme.of(context).colorScheme.primary,
-              ),
-            ),
-            onPressed: () {
-              ScaffoldMessenger.of(context).hideCurrentSnackBar();
-              Navigator.of(context).pop();
-            },
-            tooltip: 'progress.back'.tr(),
-          ),
+          automaticallyImplyLeading: false,
           title: Text(
             'progress.title'.tr(),
             style: Theme.of(context).textTheme.titleLarge?.copyWith(

--- a/lib/providers/devocional_provider.dart
+++ b/lib/providers/devocional_provider.dart
@@ -18,6 +18,7 @@ import 'package:devocional_nuevo/services/service_locator.dart';
 import 'package:devocional_nuevo/services/spiritual_stats_service.dart';
 import 'package:devocional_nuevo/services/tts/i_tts_service.dart';
 import 'package:devocional_nuevo/utils/constants/constants.dart';
+import 'package:devocional_nuevo/widgets/app_snack_bar.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -1086,19 +1087,11 @@ class DevocionalProvider with ChangeNotifier {
       final wasAdded = await toggleFavorite(devocional.id);
       if (!context.mounted) return;
 
-      final ColorScheme colorScheme = Theme.of(context).colorScheme;
-
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            wasAdded
-                ? 'devotionals_page.added_to_favorites'.tr()
-                : 'devotionals_page.removed_from_favorites'.tr(),
-            style: TextStyle(color: colorScheme.onSecondary),
-          ),
-          duration: const Duration(seconds: 2),
-          backgroundColor: colorScheme.secondary,
-        ),
+      AppSnackBar.show(
+        context,
+        wasAdded
+            ? 'devotionals_page.added_to_favorites'.tr()
+            : 'devotionals_page.removed_from_favorites'.tr(),
       );
     } catch (e) {
       if (!context.mounted) return;

--- a/lib/services/device_locale_provider.dart
+++ b/lib/services/device_locale_provider.dart
@@ -1,0 +1,18 @@
+import 'dart:ui';
+
+/// Provides the device's system locale.
+///
+/// Exists so [LocalizationService] can depend on an injectable interface
+/// rather than reading `PlatformDispatcher.instance` directly — the engine
+/// singleton has no test-controllable equivalent, so tests inject a fake
+/// implementation instead of pinning a value through a production API.
+abstract class DeviceLocaleProvider {
+  Locale get locale;
+}
+
+class PlatformDeviceLocaleProvider implements DeviceLocaleProvider {
+  const PlatformDeviceLocaleProvider();
+
+  @override
+  Locale get locale => PlatformDispatcher.instance.locale;
+}

--- a/lib/services/localization_service.dart
+++ b/lib/services/localization_service.dart
@@ -70,6 +70,12 @@ class LocalizationService implements ILocalizationService {
       final savedLocale = Locale(savedLocaleCode);
       if (supportedLocales.contains(savedLocale)) {
         _currentLocale = savedLocale;
+      } else {
+        // Saved code is unsupported/stale — fall back and correct the
+        // persisted value so downstream readers of 'locale' don't keep
+        // seeing the invalid code.
+        _currentLocale = _detectDeviceLocale();
+        await prefs.setString('locale', _currentLocale.languageCode);
       }
     } else {
       // Auto-detect device locale

--- a/lib/services/localization_service.dart
+++ b/lib/services/localization_service.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'device_locale_provider.dart';
 import 'i_localization_service.dart';
 
 /// Service for managing app localization and translations.
@@ -24,7 +25,14 @@ import 'i_localization_service.dart';
 class LocalizationService implements ILocalizationService {
   /// Default constructor for DI registration.
   /// The Service Locator will create and manage the singleton instance.
-  LocalizationService();
+  /// [deviceLocaleProvider] defaults to the real platform provider; tests
+  /// inject a fake to control the detected device locale deterministically.
+  LocalizationService({
+    DeviceLocaleProvider deviceLocaleProvider =
+        const PlatformDeviceLocaleProvider(),
+  }) : _deviceLocaleProvider = deviceLocaleProvider;
+
+  final DeviceLocaleProvider _deviceLocaleProvider;
 
   // Supported locales
   static const List<Locale> supportedLocales = [
@@ -115,12 +123,9 @@ class LocalizationService implements ILocalizationService {
     }
   }
 
-  /// Detect device locale with fallback to default.
-  /// [deviceLocale] is exposed only so tests can pin a value —
-  /// PlatformDispatcher.instance has no test-controllable equivalent.
-  /// Production call sites should never pass this.
-  Locale _detectDeviceLocale({Locale? deviceLocale}) {
-    final locale = deviceLocale ?? PlatformDispatcher.instance.locale;
+  /// Detect device locale with fallback to default
+  Locale _detectDeviceLocale() {
+    final locale = _deviceLocaleProvider.locale;
 
     // Check if device locale is supported
     for (final supportedLocale in supportedLocales) {

--- a/lib/services/localization_service.dart
+++ b/lib/services/localization_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:developer' as developer;
 import 'dart:ui';
 
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
@@ -91,7 +92,9 @@ class LocalizationService implements ILocalizationService {
 
   /// Persist the locale code to SharedPreferences, logging (not throwing)
   /// on failure — consistent with the non-fatal error handling used
-  /// elsewhere in this service (see `_loadTranslations`).
+  /// elsewhere in this service (see `_loadTranslations`). Also reported to
+  /// Crashlytics: a silent failure here means notification language
+  /// selection keeps reading a stale/incorrect locale indefinitely.
   Future<void> _persistLocale(
       SharedPreferences prefs, String languageCode) async {
     try {
@@ -103,16 +106,25 @@ class LocalizationService implements ILocalizationService {
         error: e,
         stackTrace: stackTrace,
       );
+      FirebaseCrashlytics.instance.recordError(
+        e,
+        stackTrace,
+        reason: 'Failed to persist locale: $languageCode',
+        fatal: false,
+      );
     }
   }
 
-  /// Detect device locale with fallback to default
-  Locale _detectDeviceLocale() {
-    final deviceLocale = PlatformDispatcher.instance.locale;
+  /// Detect device locale with fallback to default.
+  /// [deviceLocale] is exposed only so tests can pin a value —
+  /// PlatformDispatcher.instance has no test-controllable equivalent.
+  /// Production call sites should never pass this.
+  Locale _detectDeviceLocale({Locale? deviceLocale}) {
+    final locale = deviceLocale ?? PlatformDispatcher.instance.locale;
 
     // Check if device locale is supported
     for (final supportedLocale in supportedLocales) {
-      if (supportedLocale.languageCode == deviceLocale.languageCode) {
+      if (supportedLocale.languageCode == locale.languageCode) {
         return supportedLocale;
       }
     }

--- a/lib/services/localization_service.dart
+++ b/lib/services/localization_service.dart
@@ -75,18 +75,35 @@ class LocalizationService implements ILocalizationService {
         // persisted value so downstream readers of 'locale' don't keep
         // seeing the invalid code.
         _currentLocale = _detectDeviceLocale();
-        await prefs.setString('locale', _currentLocale.languageCode);
+        await _persistLocale(prefs, _currentLocale.languageCode);
       }
     } else {
       // Auto-detect device locale
       _currentLocale = _detectDeviceLocale();
       // Persist so downstream reads of the 'locale' key (e.g. notification
       // language selection) see the detected locale, not just in-memory state.
-      await prefs.setString('locale', _currentLocale.languageCode);
+      await _persistLocale(prefs, _currentLocale.languageCode);
     }
 
     // Load translations for current locale
     await _loadTranslations(_currentLocale.languageCode);
+  }
+
+  /// Persist the locale code to SharedPreferences, logging (not throwing)
+  /// on failure — consistent with the non-fatal error handling used
+  /// elsewhere in this service (see `_loadTranslations`).
+  Future<void> _persistLocale(
+      SharedPreferences prefs, String languageCode) async {
+    try {
+      await prefs.setString('locale', languageCode);
+    } catch (e, stackTrace) {
+      developer.log(
+        'Failed to persist locale: $languageCode',
+        name: 'LocalizationService',
+        error: e,
+        stackTrace: stackTrace,
+      );
+    }
   }
 
   /// Detect device locale with fallback to default
@@ -182,7 +199,7 @@ class LocalizationService implements ILocalizationService {
 
     // Save to preferences
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString('locale', locale.languageCode);
+    await _persistLocale(prefs, locale.languageCode);
 
     // Load new translations
     await _loadTranslations(locale.languageCode);

--- a/lib/services/localization_service.dart
+++ b/lib/services/localization_service.dart
@@ -74,6 +74,9 @@ class LocalizationService implements ILocalizationService {
     } else {
       // Auto-detect device locale
       _currentLocale = _detectDeviceLocale();
+      // Persist so downstream reads of the 'locale' key (e.g. notification
+      // language selection) see the detected locale, not just in-memory state.
+      await prefs.setString('locale', _currentLocale.languageCode);
     }
 
     // Load translations for current locale

--- a/lib/services/localization_service.dart
+++ b/lib/services/localization_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:developer' as developer;
 import 'dart:ui';
@@ -114,11 +115,13 @@ class LocalizationService implements ILocalizationService {
         error: e,
         stackTrace: stackTrace,
       );
-      FirebaseCrashlytics.instance.recordError(
-        e,
-        stackTrace,
-        reason: 'Failed to persist locale: $languageCode',
-        fatal: false,
+      unawaited(
+        FirebaseCrashlytics.instance.recordError(
+          e,
+          stackTrace,
+          reason: 'Failed to persist locale: $languageCode',
+          fatal: false,
+        ),
       );
     }
   }

--- a/lib/services/service_locator.dart
+++ b/lib/services/service_locator.dart
@@ -26,6 +26,7 @@ import 'package:devocional_nuevo/services/backup/google_drive_auth_service.dart'
 import 'package:devocional_nuevo/services/backup/google_drive_backup_service.dart';
 import 'package:devocional_nuevo/services/backup/i_backup_settings_service.dart';
 import 'package:devocional_nuevo/services/backup/backup_settings_service.dart';
+import 'package:devocional_nuevo/services/device_locale_provider.dart';
 import 'package:devocional_nuevo/services/i_connectivity_service.dart';
 import 'package:devocional_nuevo/services/i_encounter_progress_service.dart';
 import 'package:devocional_nuevo/services/backup/i_google_drive_auth_service.dart';
@@ -110,8 +111,13 @@ Future<void> setupServiceLocator() async {
 
   locator.registerLazySingleton<IAuthService>(() => FirebaseAuthService());
 
+  locator.registerLazySingleton<DeviceLocaleProvider>(
+    () => const PlatformDeviceLocaleProvider(),
+  );
   locator.registerLazySingleton<LocalizationService>(
-    () => LocalizationService(),
+    () => LocalizationService(
+      deviceLocaleProvider: locator.get<DeviceLocaleProvider>(),
+    ),
   );
   locator.registerSingleton<ILocalizationService>(
     locator.get<LocalizationService>(),

--- a/lib/utils/clipboard_utils.dart
+++ b/lib/utils/clipboard_utils.dart
@@ -1,4 +1,5 @@
 import 'package:devocional_nuevo/extensions/string_extensions.dart';
+import 'package:devocional_nuevo/widgets/app_snack_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -13,17 +14,7 @@ class ClipboardUtils {
       await Clipboard.setData(ClipboardData(text: text));
       if (!context.mounted) return;
       HapticFeedback.selectionClick();
-      final colorScheme = Theme.of(context).colorScheme;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          backgroundColor: colorScheme.secondary,
-          duration: const Duration(seconds: 2),
-          content: Text(
-            'share.copied_to_clipboard'.tr(),
-            style: TextStyle(color: colorScheme.onSecondary),
-          ),
-        ),
-      );
+      AppSnackBar.show(context, 'share.copied_to_clipboard'.tr());
     } catch (e) {
       debugPrint('[ClipboardUtils] Error copying to clipboard: $e');
     }

--- a/lib/widgets/add_prayer_modal.dart
+++ b/lib/widgets/add_prayer_modal.dart
@@ -4,6 +4,7 @@ import 'package:devocional_nuevo/blocs/prayer_bloc.dart';
 import 'package:devocional_nuevo/blocs/prayer_event.dart';
 import 'package:devocional_nuevo/extensions/string_extensions.dart';
 import 'package:devocional_nuevo/models/prayer_model.dart';
+import 'package:devocional_nuevo/widgets/app_snack_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -324,27 +325,6 @@ class _AddPrayerModalState extends State<AddPrayerModal> {
   }
 
   void _showSuccessSnackBar(String message) {
-    final colorScheme = Theme.of(context).colorScheme;
-
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Row(
-          children: [
-            Icon(Icons.check_circle_outline, color: colorScheme.onSecondary),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Text(
-                message,
-                style: TextStyle(color: colorScheme.onSecondary),
-              ),
-            ),
-          ],
-        ),
-        backgroundColor: colorScheme.secondary,
-        duration: const Duration(seconds: 2),
-        behavior: SnackBarBehavior.floating,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-      ),
-    );
+    AppSnackBar.show(context, message, icon: Icons.check_circle_outline);
   }
 }

--- a/lib/widgets/add_testimony_modal.dart
+++ b/lib/widgets/add_testimony_modal.dart
@@ -6,6 +6,7 @@ import 'package:devocional_nuevo/extensions/string_extensions.dart';
 import 'package:devocional_nuevo/models/testimony_model.dart';
 import 'package:devocional_nuevo/services/localization_service.dart';
 import 'package:devocional_nuevo/services/service_locator.dart';
+import 'package:devocional_nuevo/widgets/app_snack_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -330,27 +331,6 @@ class _AddTestimonyModalState extends State<AddTestimonyModal> {
   }
 
   void _showSuccessSnackBar(String message) {
-    final colorScheme = Theme.of(context).colorScheme;
-
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Row(
-          children: [
-            Icon(Icons.check_circle_outline, color: colorScheme.onSecondary),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Text(
-                message,
-                style: TextStyle(color: colorScheme.onSecondary),
-              ),
-            ),
-          ],
-        ),
-        backgroundColor: colorScheme.secondary,
-        duration: const Duration(seconds: 2),
-        behavior: SnackBarBehavior.floating,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-      ),
-    );
+    AppSnackBar.show(context, message, icon: Icons.check_circle_outline);
   }
 }

--- a/lib/widgets/add_thanksgiving_modal.dart
+++ b/lib/widgets/add_thanksgiving_modal.dart
@@ -4,6 +4,7 @@ import 'package:devocional_nuevo/blocs/thanksgiving_bloc.dart';
 import 'package:devocional_nuevo/blocs/thanksgiving_event.dart';
 import 'package:devocional_nuevo/extensions/string_extensions.dart';
 import 'package:devocional_nuevo/models/thanksgiving_model.dart';
+import 'package:devocional_nuevo/widgets/app_snack_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -328,27 +329,6 @@ class _AddThanksgivingModalState extends State<AddThanksgivingModal> {
   }
 
   void _showSuccessSnackBar(String message) {
-    final colorScheme = Theme.of(context).colorScheme;
-
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Row(
-          children: [
-            Icon(Icons.check_circle_outline, color: colorScheme.onSecondary),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Text(
-                message,
-                style: TextStyle(color: colorScheme.onSecondary),
-              ),
-            ),
-          ],
-        ),
-        backgroundColor: colorScheme.secondary,
-        duration: const Duration(seconds: 2),
-        behavior: SnackBarBehavior.floating,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-      ),
-    );
+    AppSnackBar.show(context, message, icon: Icons.check_circle_outline);
   }
 }

--- a/lib/widgets/app_snack_bar.dart
+++ b/lib/widgets/app_snack_bar.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+/// Visual variant of [AppSnackBar]. Determines background/text color.
+enum AppSnackBarType { feedback, tip }
+
+/// Single reusable floating snackbar style for the whole app.
+///
+/// Replaces ad-hoc `ScaffoldMessenger.showSnackBar` calls scattered across
+/// pages so every snackbar shares the same shape (floating, rounded corners)
+/// and color rules instead of each call site redefining them.
+class AppSnackBar {
+  AppSnackBar._();
+
+  static void show(
+    BuildContext context,
+    String message, {
+    AppSnackBarType type = AppSnackBarType.feedback,
+    IconData? icon,
+    Color? iconColor,
+    String? title,
+    Duration duration = const Duration(seconds: 2),
+    SnackBarAction? action,
+  }) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final backgroundColor =
+        type == AppSnackBarType.tip ? colorScheme.primary : colorScheme.secondary;
+    final foregroundColor =
+        type == AppSnackBarType.tip ? Colors.white : colorScheme.onSecondary;
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Row(
+          children: [
+            if (icon != null) ...[
+              Icon(icon, size: 20, color: iconColor ?? foregroundColor),
+              const SizedBox(width: 12),
+            ],
+            Expanded(
+              child: title == null
+                  ? Text(message, style: TextStyle(color: foregroundColor))
+                  : Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          title,
+                          style: TextStyle(
+                            fontWeight: FontWeight.w600,
+                            fontSize: 14,
+                            color: foregroundColor,
+                          ),
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          message,
+                          style: TextStyle(fontSize: 13, color: foregroundColor),
+                        ),
+                      ],
+                    ),
+            ),
+          ],
+        ),
+        duration: duration,
+        backgroundColor: backgroundColor,
+        behavior: SnackBarBehavior.floating,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        action: action,
+      ),
+    );
+  }
+}

--- a/lib/widgets/app_snack_bar.dart
+++ b/lib/widgets/app_snack_bar.dart
@@ -11,6 +11,8 @@ enum AppSnackBarType { feedback, tip }
 class AppSnackBar {
   AppSnackBar._();
 
+  static const Duration duration = Duration(seconds: 3);
+
   static void show(
     BuildContext context,
     String message, {
@@ -18,12 +20,12 @@ class AppSnackBar {
     IconData? icon,
     Color? iconColor,
     String? title,
-    Duration duration = const Duration(seconds: 2),
     SnackBarAction? action,
   }) {
     final colorScheme = Theme.of(context).colorScheme;
-    final backgroundColor =
-        type == AppSnackBarType.tip ? colorScheme.primary : colorScheme.secondary;
+    final backgroundColor = type == AppSnackBarType.tip
+        ? colorScheme.primary
+        : colorScheme.secondary;
     final foregroundColor =
         type == AppSnackBarType.tip ? Colors.white : colorScheme.onSecondary;
 
@@ -53,7 +55,8 @@ class AppSnackBar {
                         const SizedBox(height: 2),
                         Text(
                           message,
-                          style: TextStyle(fontSize: 13, color: foregroundColor),
+                          style:
+                              TextStyle(fontSize: 13, color: foregroundColor),
                         ),
                       ],
                     ),

--- a/lib/widgets/devocionales/devocionales_page_drawer.dart
+++ b/lib/widgets/devocionales/devocionales_page_drawer.dart
@@ -9,6 +9,7 @@ import 'package:devocional_nuevo/providers/devocional_provider.dart';
 import 'package:devocional_nuevo/services/in_app_review_service.dart';
 import 'package:devocional_nuevo/utils/constants/bubble_constants.dart';
 import 'package:devocional_nuevo/widgets/app_gradient_dialog.dart';
+import 'package:devocional_nuevo/widgets/app_snack_bar.dart';
 import 'package:devocional_nuevo/widgets/theme_selector.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -688,16 +689,10 @@ class _DevocionalesDrawerState extends State<DevocionalesDrawer> {
                                   Navigator.of(
                                     context,
                                   ).pop(); // Cierra el Drawer
-                                  ScaffoldMessenger.of(context).showSnackBar(
-                                    SnackBar(
-                                      content: Text(
-                                        'drawer.offline_access_ready'.tr(),
-                                      ),
-                                      backgroundColor: Theme.of(
-                                        context,
-                                      ).colorScheme.primary,
-                                      duration: const Duration(seconds: 2),
-                                    ),
+                                  AppSnackBar.show(
+                                    context,
+                                    'drawer.offline_access_ready'.tr(),
+                                    type: AppSnackBarType.tip,
                                   );
                                 }
                               },

--- a/lib/widgets/devocionales/devocionales_page_drawer.dart
+++ b/lib/widgets/devocionales/devocionales_page_drawer.dart
@@ -3,14 +3,11 @@ import 'package:devocional_nuevo/blocs/theme/theme_bloc.dart';
 import 'package:devocional_nuevo/blocs/theme/theme_event.dart';
 import 'package:devocional_nuevo/blocs/theme/theme_state.dart';
 import 'package:devocional_nuevo/extensions/string_extensions.dart';
-import 'package:devocional_nuevo/pages/discovery_bible_studies/discovery_list_page.dart';
 import 'package:devocional_nuevo/pages/favorites_page.dart';
 import 'package:devocional_nuevo/pages/notification_config_page.dart';
-import 'package:devocional_nuevo/pages/prayers_page.dart';
 import 'package:devocional_nuevo/providers/devocional_provider.dart';
 import 'package:devocional_nuevo/services/in_app_review_service.dart';
 import 'package:devocional_nuevo/utils/constants/bubble_constants.dart';
-import 'package:devocional_nuevo/utils/constants/constants.dart';
 import 'package:devocional_nuevo/widgets/app_gradient_dialog.dart';
 import 'package:devocional_nuevo/widgets/theme_selector.dart';
 import 'package:flutter/material.dart';
@@ -530,52 +527,6 @@ class _DevocionalesDrawerState extends State<DevocionalesDrawer> {
                           },
                         ),
                         const SizedBox(height: 5),
-                        // --- Mis oraciones ---
-                        drawerRow(
-                          key: const Key('drawer_my_prayers'),
-                          icon: Icons.local_fire_department_outlined,
-                          iconColor: colorScheme.primary,
-                          label: Text(
-                            'drawer.my_prayers'.tr(),
-                            style: textTheme.bodyMedium?.copyWith(
-                              fontSize: 16,
-                              color: colorScheme.onSurface,
-                            ),
-                          ),
-                          onTap: () {
-                            Navigator.of(context).pop();
-                            Navigator.of(context).push(
-                              MaterialPageRoute(
-                                builder: (_) => const PrayersPage(),
-                              ),
-                            );
-                          },
-                        ),
-                        const SizedBox(height: 5),
-                        // --- Discovery Studies ---
-                        if (Constants.enableDiscoveryFeature)
-                          drawerRow(
-                            key: const Key('drawer_discovery_studies'),
-                            icon: Icons.school_outlined,
-                            iconColor: colorScheme.primary,
-                            label: Text(
-                              'discovery.discovery_studies'.tr(),
-                              style: textTheme.bodyMedium?.copyWith(
-                                fontSize: 16,
-                                color: colorScheme.onSurface,
-                              ),
-                            ),
-                            onTap: () {
-                              Navigator.of(context).pop();
-                              Navigator.of(context).push(
-                                MaterialPageRoute(
-                                  builder: (_) => const DiscoveryListPage(),
-                                ),
-                              );
-                            },
-                          ),
-                        if (Constants.enableDiscoveryFeature)
-                          const SizedBox(height: 5),
                         // --- Switch modo oscuro ---
                         drawerRow(
                           key: const Key('drawer_dark_mode_toggle'),

--- a/lib/widgets/supporter/supporter_bronze_silver_purchase_dialog.dart
+++ b/lib/widgets/supporter/supporter_bronze_silver_purchase_dialog.dart
@@ -1,7 +1,8 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:devocional_nuevo/extensions/string_extensions.dart';
 import 'package:devocional_nuevo/models/supporter_tier.dart';
-import 'package:devocional_nuevo/pages/progress_page.dart';
+import 'package:devocional_nuevo/pages/app_navigation_shell.dart';
+import 'package:devocional_nuevo/widgets/app_bottom_nav_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:lottie/lottie.dart';
 
@@ -88,10 +89,7 @@ class _SupporterPurchaseDialogState extends State<SupporterPurchaseDialog>
     setState(() => _isLoading = false);
     Navigator.pop(context); // Use local context, not widget.dialogContext
     if (goToProgress && mounted) {
-      Navigator.push(
-        context,
-        MaterialPageRoute(builder: (_) => const ProgressPage()),
-      );
+      AppNavigationShell.selectTab(AppTab.progress);
     }
   }
 

--- a/test/migration/no_singleton_antipatterns_test.dart
+++ b/test/migration/no_singleton_antipatterns_test.dart
@@ -54,9 +54,10 @@ void main() {
       final file = File('lib/services/localization_service.dart');
       final content = await file.readAsString();
 
-      // Assert public constructor exists
+      // Assert public constructor exists (takes an optional injected
+      // DeviceLocaleProvider, so it is no longer a bare no-arg constructor).
       expect(
-        content.contains('LocalizationService()'),
+        content.contains('LocalizationService({'),
         isTrue,
         reason: 'LocalizationService should have public constructor for DI',
       );
@@ -82,7 +83,7 @@ void main() {
       );
 
       expect(
-        content.contains('LocalizationService()'),
+        content.contains('LocalizationService('),
         isTrue,
         reason:
             'LocalizationService should be instantiated via public constructor in ServiceLocator',

--- a/test/migration/no_singleton_antipatterns_test.dart
+++ b/test/migration/no_singleton_antipatterns_test.dart
@@ -109,6 +109,71 @@ void main() {
       );
     });
 
+    // ── DeviceLocaleProvider DI registration ───────────────────────────────
+
+    test(
+      'DeviceLocaleProvider is registered in ServiceLocator and injected into LocalizationService',
+      () async {
+        final file = File('lib/services/service_locator.dart');
+        expect(
+          await file.exists(),
+          isTrue,
+          reason: 'ServiceLocator source file should exist',
+        );
+
+        final content = await file.readAsString();
+
+        expect(
+          content.contains('registerLazySingleton<DeviceLocaleProvider>('),
+          isTrue,
+          reason:
+              'DeviceLocaleProvider should be registered as a lazy singleton in ServiceLocator',
+        );
+
+        expect(
+          content.contains(
+            'deviceLocaleProvider: locator.get<DeviceLocaleProvider>()',
+          ),
+          isTrue,
+          reason:
+              'LocalizationService should receive DeviceLocaleProvider via constructor injection, not read PlatformDispatcher.instance directly',
+        );
+      },
+    );
+
+    test(
+      'PlatformDeviceLocaleProvider is not instantiated directly outside service_locator.dart',
+      () async {
+        final libDir = Directory('lib');
+        expect(
+          await libDir.exists(),
+          isTrue,
+          reason: 'lib directory should exist',
+        );
+
+        await for (final entity in libDir.list(recursive: true)) {
+          if (entity is! File || !entity.path.endsWith('.dart')) continue;
+          if (entity.path.endsWith('service_locator.dart')) continue;
+          if (entity.path.endsWith('device_locale_provider.dart')) continue;
+          // LocalizationService's constructor references
+          // PlatformDeviceLocaleProvider only as its default parameter
+          // value (the standard DI fallback-default pattern) — the actual
+          // instance used at runtime is still the one service_locator.dart
+          // constructs and injects.
+          if (entity.path.endsWith('localization_service.dart')) continue;
+
+          final content = await entity.readAsString();
+          expect(
+            content.contains('PlatformDeviceLocaleProvider('),
+            isFalse,
+            reason:
+                'PlatformDeviceLocaleProvider should only be instantiated in '
+                'service_locator.dart, found in ${entity.path}',
+          );
+        }
+      },
+    );
+
     test('Codebase does not reference LocalizationService.instance', () async {
       // Check lib directory
       final libDir = Directory('lib');

--- a/test/unit/services/localization_service_test.dart
+++ b/test/unit/services/localization_service_test.dart
@@ -257,6 +257,14 @@ void main() {
               .contains(localizationService.currentLocale.languageCode),
           isTrue,
         );
+
+        // The stale/unsupported value must be corrected in SharedPreferences,
+        // not just in memory, so other readers of 'locale' see the fallback.
+        final prefs = await SharedPreferences.getInstance();
+        expect(
+          prefs.getString('locale'),
+          equals(localizationService.currentLocale.languageCode),
+        );
       },
     );
 

--- a/test/unit/services/localization_service_test.dart
+++ b/test/unit/services/localization_service_test.dart
@@ -3,11 +3,19 @@ library;
 
 import 'dart:ui';
 
+import 'package:devocional_nuevo/services/device_locale_provider.dart';
 import 'package:devocional_nuevo/services/localization_service.dart';
 import 'package:devocional_nuevo/services/service_locator.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+class FakeDeviceLocaleProvider implements DeviceLocaleProvider {
+  FakeDeviceLocaleProvider(this.locale);
+
+  @override
+  final Locale locale;
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -225,36 +233,23 @@ void main() {
     test(
       'initialize() persists auto-detected locale to SharedPreferences when none is saved',
       () async {
-        // NOTE: PlatformDispatcher.instance is a fixed engine singleton;
-        // TestPlatformDispatcher.localeTestValue only affects code reading
-        // the locale via WidgetsBinding, not PlatformDispatcher.instance
-        // directly (which is what _detectDeviceLocale() uses) — so the
-        // device locale cannot be pinned in a plain `test()`. Instead,
-        // independently recompute the expected outcome from the same
-        // supportedLocales/defaultLocale inputs the production code uses,
-        // rather than asserting currentLocale against itself.
-        final deviceLanguageCode =
-            PlatformDispatcher.instance.locale.languageCode;
-        final expectedLanguageCode = LocalizationService.supportedLocales
-                .any((l) => l.languageCode == deviceLanguageCode)
-            ? deviceLanguageCode
-            : LocalizationService.defaultLocale.languageCode;
-
-        // No 'locale' key saved — forces the auto-detect branch
+        // No 'locale' key saved — forces the auto-detect branch. Inject a
+        // fake DeviceLocaleProvider so the expected outcome is a fixed
+        // literal, independent of both currentLocale and whatever locale
+        // the test runner's environment happens to report.
         ServiceLocator().reset();
         SharedPreferences.setMockInitialValues({});
         await setupServiceLocator();
 
-        localizationService = getService<LocalizationService>();
+        localizationService = LocalizationService(
+          deviceLocaleProvider: FakeDeviceLocaleProvider(const Locale('fr')),
+        );
         await localizationService.initialize();
 
-        expect(
-          localizationService.currentLocale.languageCode,
-          equals(expectedLanguageCode),
-        );
+        expect(localizationService.currentLocale.languageCode, equals('fr'));
 
         final prefs = await SharedPreferences.getInstance();
-        expect(prefs.getString('locale'), equals(expectedLanguageCode));
+        expect(prefs.getString('locale'), equals('fr'));
       },
     );
 
@@ -301,34 +296,22 @@ void main() {
     test(
       'initialize() uses default locale when saved locale is unsupported',
       () async {
-        // See note above: the device locale cannot be pinned via
-        // TestPlatformDispatcher because _detectDeviceLocale() reads
-        // PlatformDispatcher.instance directly. Recompute the expected
-        // outcome from the same inputs the production code uses.
-        final deviceLanguageCode =
-            PlatformDispatcher.instance.locale.languageCode;
-        final expectedLanguageCode = LocalizationService.supportedLocales
-                .any((l) => l.languageCode == deviceLanguageCode)
-            ? deviceLanguageCode
-            : LocalizationService.defaultLocale.languageCode;
-
-        // Set up with unsupported locale
+        // Inject a fake DeviceLocaleProvider — see note above.
         ServiceLocator().reset();
         SharedPreferences.setMockInitialValues({'locale': 'xx'});
         await setupServiceLocator();
-        localizationService = getService<LocalizationService>();
+        localizationService = LocalizationService(
+          deviceLocaleProvider: FakeDeviceLocaleProvider(const Locale('de')),
+        );
         await localizationService.initialize();
 
-        // Should fall back to the detected device locale
-        expect(
-          localizationService.currentLocale.languageCode,
-          equals(expectedLanguageCode),
-        );
+        // Should fall back to the pinned device locale
+        expect(localizationService.currentLocale.languageCode, equals('de'));
 
         // The stale/unsupported value must be corrected in SharedPreferences,
         // not just in memory, so other readers of 'locale' see the fallback.
         final prefs = await SharedPreferences.getInstance();
-        expect(prefs.getString('locale'), equals(expectedLanguageCode));
+        expect(prefs.getString('locale'), equals('de'));
       },
     );
 

--- a/test/unit/services/localization_service_test.dart
+++ b/test/unit/services/localization_service_test.dart
@@ -5,6 +5,7 @@ import 'dart:ui';
 
 import 'package:devocional_nuevo/services/localization_service.dart';
 import 'package:devocional_nuevo/services/service_locator.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -224,6 +225,21 @@ void main() {
     test(
       'initialize() persists auto-detected locale to SharedPreferences when none is saved',
       () async {
+        // NOTE: PlatformDispatcher.instance is a fixed engine singleton;
+        // TestPlatformDispatcher.localeTestValue only affects code reading
+        // the locale via WidgetsBinding, not PlatformDispatcher.instance
+        // directly (which is what _detectDeviceLocale() uses) — so the
+        // device locale cannot be pinned in a plain `test()`. Instead,
+        // independently recompute the expected outcome from the same
+        // supportedLocales/defaultLocale inputs the production code uses,
+        // rather than asserting currentLocale against itself.
+        final deviceLanguageCode =
+            PlatformDispatcher.instance.locale.languageCode;
+        final expectedLanguageCode = LocalizationService.supportedLocales
+                .any((l) => l.languageCode == deviceLanguageCode)
+            ? deviceLanguageCode
+            : LocalizationService.defaultLocale.languageCode;
+
         // No 'locale' key saved — forces the auto-detect branch
         ServiceLocator().reset();
         SharedPreferences.setMockInitialValues({});
@@ -232,10 +248,52 @@ void main() {
         localizationService = getService<LocalizationService>();
         await localizationService.initialize();
 
-        final prefs = await SharedPreferences.getInstance();
         expect(
-          prefs.getString('locale'),
-          equals(localizationService.currentLocale.languageCode),
+          localizationService.currentLocale.languageCode,
+          equals(expectedLanguageCode),
+        );
+
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.getString('locale'), equals(expectedLanguageCode));
+      },
+    );
+
+    test(
+      'initialize() does not throw when SharedPreferences write fails',
+      () async {
+        // Force setString to throw by feeding the plugin an invalid initial
+        // value type via the mock method channel, simulating a persistence
+        // failure (e.g. disk full) on the auto-detect persistence path.
+        ServiceLocator().reset();
+        SharedPreferences.setMockInitialValues({});
+        await setupServiceLocator();
+
+        const channel = MethodChannel(
+          'plugins.flutter.io/shared_preferences',
+        );
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (methodCall) async {
+          if (methodCall.method == 'setString') {
+            throw PlatformException(
+              code: 'test_error',
+              message: 'Simulated SharedPreferences write failure',
+            );
+          }
+          return true;
+        });
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(channel, null);
+        });
+
+        localizationService = getService<LocalizationService>();
+
+        // Must not throw — persistence failures are caught and logged, not
+        // propagated, so app startup / language switching cannot crash on
+        // a SharedPreferences write error.
+        await expectLater(
+          localizationService.initialize(),
+          completes,
         );
       },
     );
@@ -243,6 +301,17 @@ void main() {
     test(
       'initialize() uses default locale when saved locale is unsupported',
       () async {
+        // See note above: the device locale cannot be pinned via
+        // TestPlatformDispatcher because _detectDeviceLocale() reads
+        // PlatformDispatcher.instance directly. Recompute the expected
+        // outcome from the same inputs the production code uses.
+        final deviceLanguageCode =
+            PlatformDispatcher.instance.locale.languageCode;
+        final expectedLanguageCode = LocalizationService.supportedLocales
+                .any((l) => l.languageCode == deviceLanguageCode)
+            ? deviceLanguageCode
+            : LocalizationService.defaultLocale.languageCode;
+
         // Set up with unsupported locale
         ServiceLocator().reset();
         SharedPreferences.setMockInitialValues({'locale': 'xx'});
@@ -250,21 +319,16 @@ void main() {
         localizationService = getService<LocalizationService>();
         await localizationService.initialize();
 
-        // Should fall back to a supported locale
+        // Should fall back to the detected device locale
         expect(
-          LocalizationService.supportedLocales
-              .map((l) => l.languageCode)
-              .contains(localizationService.currentLocale.languageCode),
-          isTrue,
+          localizationService.currentLocale.languageCode,
+          equals(expectedLanguageCode),
         );
 
         // The stale/unsupported value must be corrected in SharedPreferences,
         // not just in memory, so other readers of 'locale' see the fallback.
         final prefs = await SharedPreferences.getInstance();
-        expect(
-          prefs.getString('locale'),
-          equals(localizationService.currentLocale.languageCode),
-        );
+        expect(prefs.getString('locale'), equals(expectedLanguageCode));
       },
     );
 

--- a/test/unit/services/localization_service_test.dart
+++ b/test/unit/services/localization_service_test.dart
@@ -222,6 +222,25 @@ void main() {
     );
 
     test(
+      'initialize() persists auto-detected locale to SharedPreferences when none is saved',
+      () async {
+        // No 'locale' key saved — forces the auto-detect branch
+        ServiceLocator().reset();
+        SharedPreferences.setMockInitialValues({});
+        await setupServiceLocator();
+
+        localizationService = getService<LocalizationService>();
+        await localizationService.initialize();
+
+        final prefs = await SharedPreferences.getInstance();
+        expect(
+          prefs.getString('locale'),
+          equals(localizationService.currentLocale.languageCode),
+        );
+      },
+    );
+
+    test(
       'initialize() uses default locale when saved locale is unsupported',
       () async {
         // Set up with unsupported locale


### PR DESCRIPTION
## Summary
- Fix `ProgressPage` losing the shell's bottom nav bar by routing the streak-badge tap and supporter purchase dialog through `AppNavigationShell.selectTab` instead of pushing a new route
- Remove back-arrow from `ProgressPage` app bar (navigation now via bottom bar)
- Tighten the single-badge (bronze/silver-only) supporter section layout to avoid a large empty gap
- Remove "Bible Studies" and "Mis oraciones" rows from the drawer (now reachable via bottom bar)
- Add `AppSnackBar` (`lib/widgets/app_snack_bar.dart`), a single reusable floating-snackbar helper (secondary/primary color variants, rounded corners, fixed 3s duration), and migrate ~17 previously ad-hoc `SnackBar` call sites to it across favorites, discovery, bible reader, notification config, backup settings, and the prayer/testimony/thanksgiving success modals
- Error-colored snackbars and debug-only snackbars intentionally left unmigrated

## Test plan
- [x] `dart analyze lib/` clean
- [ ] Manually verify bottom nav bar stays visible when tapping the streak badge and after a supporter purchase
- [ ] Manually verify migrated snackbars (favorites toggle, bible verse copy/save/delete, notification settings, backup created/restored, prayer/testimony/thanksgiving success) still show correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)