### PR TITLE
Add missing German and Filipino push notification translations

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -189,6 +189,50 @@ const NOTIFICATION_TRANSLATIONS = {
       body: "دروسك الإيمانية جاهزة لك.",
     },
   ],
+  de: [
+    {
+      // Option A — Peace space (original)
+      title: "Dein Raum des Friedens wartet auf dich",
+      body: "Denk daran, dich heute mit dem Wort Gottes zu verbinden!",
+    },
+    {
+      // Option B — Daily habit
+      title: "Deine Andacht wartet auf dich",
+      body: "Beginne den Tag mit dem Wort Gottes.",
+    },
+    {
+      // Option C — Encounter
+      title: "Gott hat heute etwas für dich",
+      body: "Öffne deine Andacht und entdecke es.",
+    },
+    {
+      // Option D — Daily habit
+      title: "Hast du heute schon Zeit mit Gott verbracht?",
+      body: "Deine Andacht ist bereit für dich.",
+    },
+  ],
+  fil: [
+    {
+      // Option A — Peace space (original)
+      title: "Naghihintay ang iyong Tahimik na Espasyo",
+      body: "Alalahanin mong makipag-ugnayan ngayon sa salita ng Diyos!",
+    },
+    {
+      // Option B — Daily habit
+      title: "Naghihintay sa iyo ang iyong debosyonal",
+      body: "Simulan ang araw kasama ang Salita ng Diyos.",
+    },
+    {
+      // Option C — Encounter
+      title: "May bagay ang Diyos para sa iyo ngayon",
+      body: "Buksan ang iyong debosyonal at tuklasin ito.",
+    },
+    {
+      // Option D — Daily habit
+      title: "Nakapaglaan ka na ba ng oras kasama ang Diyos ngayon?",
+      body: "Handa na ang iyong debosyonal para sa iyo.",
+    },
+  ],
 };
 
 const NOTIFICATION_IMAGES = [


### PR DESCRIPTION
## Summary
- The app supports 10 languages (i18n/*.json: es, en, pt, fr, ja, zh, hi, ar, de, fil), but the Cloud Function that sends daily devotional push notifications only had translations for 8 — German (`de`) and Filipino (`fil`) were missing.
- `selectLanguageForUser()` silently falls back to Spanish (`es`) for any language not in `NOTIFICATION_TRANSLATIONS`, so German and Filipino users were getting Spanish push notifications despite the app fully supporting both languages elsewhere.
- Adds the same 4 message variants (A–D) used by every other language, translated to match existing terminology in `i18n/de.json` (Andacht/Gott) and `i18n/fil.json` (Debosyonal/Diyos).

## Test plan
- [x] `node -c functions/index.js` — syntax valid
- [x] `npm run lint` in functions/ — clean
- [ ] Manually verify a German-preference and Filipino-preference user receives a notification in their own language (no automated test suite exists for functions/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)