### PR TITLE
Restore bottom nav bar after encounter welcome screen

### DIFF
--- a/lib/pages/encounters/encounter_welcome_page.dart
+++ b/lib/pages/encounters/encounter_welcome_page.dart
@@ -8,7 +8,6 @@
 // is set to true and this page is never shown again.
 
 import 'package:devocional_nuevo/extensions/string_extensions.dart';
-import 'package:devocional_nuevo/pages/encounters/encounters_list_page.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -69,15 +68,10 @@ class _EncounterWelcomePageState extends State<EncounterWelcomePage>
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool('encounter_welcome_seen', true);
     if (!mounted) return;
-    Navigator.pushReplacement(
-      context,
-      PageRouteBuilder(
-        pageBuilder: (context, animation, _) => const EncountersListPage(),
-        transitionsBuilder: (context, animation, _, child) =>
-            FadeTransition(opacity: animation, child: child),
-        transitionDuration: const Duration(milliseconds: 600),
-      ),
-    );
+    // Pop back to the shell-hosted EncountersListPage this was pushed on
+    // top of, instead of constructing a new standalone instance — that
+    // would bypass AppNavigationShell and hide the bottom nav bar.
+    Navigator.pop(context);
   }
 
   @override

--- a/lib/pages/encounters/encounters_list_page.dart
+++ b/lib/pages/encounters/encounters_list_page.dart
@@ -37,6 +37,7 @@ class _EncountersListPageState extends State<EncountersListPage>
     with SingleTickerProviderStateMixin, RouteAware {
   bool _showGridOverlay = false;
   late AnimationController _gridAnimationController;
+  final ScrollController _scrollController = ScrollController();
   int _currentIndex = 0;
 
   // Unlock animation state
@@ -82,6 +83,7 @@ class _EncountersListPageState extends State<EncountersListPage>
   void dispose() {
     routeObserver.unsubscribe(this);
     _gridAnimationController.dispose();
+    _scrollController.dispose();
     super.dispose();
   }
 
@@ -237,12 +239,14 @@ class _EncountersListPageState extends State<EncountersListPage>
             radius: const Radius.circular(8),
           ),
           child: Scrollbar(
+            controller: _scrollController,
             thumbVisibility: true,
             thickness: 10,
             radius: const Radius.circular(8),
             interactive: true,
             trackVisibility: true,
             child: ListView.builder(
+              controller: _scrollController,
               physics: const BouncingScrollPhysics(),
               padding: const EdgeInsets.symmetric(
                 horizontal: 20,

--- a/lib/pages/encounters/encounters_list_page.dart
+++ b/lib/pages/encounters/encounters_list_page.dart
@@ -116,7 +116,10 @@ class _EncountersListPageState extends State<EncountersListPage>
     final prefs = await SharedPreferences.getInstance();
     final seen = prefs.getBool('encounter_welcome_seen') ?? false;
     if (!seen && mounted) {
-      Navigator.pushReplacement(
+      // Push (not pushReplacement) so this shell-hosted page stays on the
+      // stack underneath — EncounterWelcomePage pops back into it instead
+      // of needing to construct a new, standalone (bottom-bar-less) copy.
+      Navigator.push(
         context,
         MaterialPageRoute(builder: (_) => const EncounterWelcomePage()),
       );


### PR DESCRIPTION
## Summary
- After tapping "Comenzar" on the first-time Encounters welcome screen, the app landed on a new `EncountersListPage` instance that bypassed `AppNavigationShell` entirely — no bottom nav bar.
- Root cause: `EncountersListPage._checkWelcomeSeen()` used `pushReplacement` to show `EncounterWelcomePage`, discarding the shell-hosted route. `EncounterWelcomePage._onBegin()` then had nothing to return to, so it pushed a brand-new standalone `EncountersListPage` — same root cause as the earlier `ProgressPage`/streak-badge navigation fix from this branch of work.
- Fix: push (not replace) the welcome screen so the shell-hosted page stays on the stack underneath, then pop back into it instead of constructing a new instance.

## Test plan
- [x] `dart analyze` clean on both changed files
- [x] All 17 encounter-related tests pass (`flutter test --plain-name "encounter"`)
- [ ] Manually verify: fresh install → open Encounters tab → welcome screen shows → tap "Comenzar" → bottom nav bar is visible on the encounters grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)