### PR TITLE
fix: add live auto-recovery for resume freeze (black-screen-on-resume)

### DIFF
--- a/android/app/src/main/kotlin/com/develop4god/devocional_nuevo/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/develop4god/devocional_nuevo/MainActivity.kt
@@ -45,27 +45,67 @@ class MainActivity : FlutterActivity() {
     // signal (confirmed: zero Dart log output, unresponsive to input, even the
     // Flutter debugger can't attach).
     //
-    // Because the freeze is in the very thread that would need to detect and act on
-    // it, there is no reliable way to auto-recover live. Instead, this records whether
-    // a resume was ever confirmed as actually drawn; if the app is killed while stuck
-    // (as users do today via force-close) and relaunched, the next cold start checks
+    // The freeze itself is in Flutter's raster/UI thread, which can't detect or act on
+    // its own hang — but this activity's Android platform thread is separate and stays
+    // responsive, which is what the "Live auto-recovery" block below uses to recover
+    // live (see that comment for the active mitigation). This block instead records
+    // whether a resume was ever confirmed as actually drawn, for the case where the
+    // live recovery attempt doesn't help and the app is later killed while still stuck
+    // (as users do today via force-close) and relaunched: the next cold start checks
     // ApplicationExitInfo (API 30+) to see if the previous exit actually looks like
     // this bug (ANR/crash/signal) rather than an ordinary OS-reaped background kill
     // or the user just closing the app normally, and reports it to Crashlytics as a
-    // non-fatal event if so.
-    //
-    // This is deliberately a temporary diagnostic, not permanent instrumentation:
-    // once there's enough production data to know whether this is worth an active
-    // fix, remove this block (this comment, the prefs, onPause/onFlutterSurfaceView-
-    // Created's watchdog wiring, reportStaleResumeMarkerIfAny, the resume_watchdog
-    // channel, and the matching Dart side in main.dart's _confirmResumeDrawn). The
-    // requestLayout() nudge in onResume() below is a separate, permanent mitigation
-    // and should stay regardless of what this telemetry finds.
+    // non-fatal event if so — this remains the production signal for how often live
+    // recovery isn't enough.
     private val watchdogPrefs: SharedPreferences by lazy {
         getSharedPreferences("resume_watchdog", MODE_PRIVATE)
     }
     private val prefKeyPending = "resume_pending"
     private val prefKeyPendingSince = "resume_pending_since_ms"
+
+    // ---- Live auto-recovery ----
+    // Added 2026-08-05, after production telemetry (573+ affected users, spanning
+    // Android 8-16 and all major OEMs, correlated with low free RAM) confirmed this
+    // is a real, frequent failure rather than a rare edge case. The freeze itself
+    // (Flutter's raster/UI thread stuck, per the diagnostic above) can't detect or
+    // fix itself — but this timer runs on the Android platform main thread, which is
+    // separate from Flutter's engine threads, so it keeps running even while Flutter
+    // is frozen. If no confirmResumeDrawn() call arrives within resumeConfirmTimeoutMs,
+    // this activity is recreated once to force the engine's surface to reattach
+    // cleanly.
+    //
+    // recreate() can destroy this Activity instance and create a fresh one, so the
+    // one-attempt guard is persisted in prefs (survives instance recreation) rather
+    // than kept as a plain field. It's cleared on a confirmed-drawn resume or a fresh
+    // cold start; if recreate() doesn't fix it, the guard stays set so this fires at
+    // most once per stuck cycle, and onCreate()'s reportStaleResumeMarkerIfAny() still
+    // reports to Crashlytics on the next cold start instead of looping.
+    private val prefKeyRecreateAttempted = "resume_recreate_attempted"
+    private val resumeConfirmTimeoutMs = 3000L
+    private var resumeConfirmed = false
+    private val resumeWatchdogHandler = Handler(Looper.getMainLooper())
+    private val resumeTimeoutRunnable = Runnable {
+        if (!resumeConfirmed && !watchdogPrefs.getBoolean(prefKeyRecreateAttempted, false)) {
+            watchdogPrefs.edit().putBoolean(prefKeyRecreateAttempted, true).apply()
+            FirebaseCrashlytics.getInstance().log(
+                "resume_watchdog: triggered, resume not confirmed within ${resumeConfirmTimeoutMs}ms, calling recreate()"
+            )
+            // recreate() can throw if the activity is already finishing/destroyed by
+            // the time this delayed callback fires (e.g. user navigated away in the
+            // interim). Never let a failed recovery attempt crash the app outright —
+            // the existing reportStaleResumeMarkerIfAny() path still catches this case
+            // via ApplicationExitInfo on the next cold start if recovery didn't work.
+            try {
+                recreate()
+                FirebaseCrashlytics.getInstance().log("resume_watchdog: recreate() call returned normally")
+            } catch (e: Exception) {
+                FirebaseCrashlytics.getInstance().log(
+                    "resume_watchdog: recreate() threw: ${e.javaClass.simpleName}: ${e.message}"
+                )
+                FirebaseCrashlytics.getInstance().recordException(e)
+            }
+        }
+    }
 
     // --- INICIO: Soporte para Firebase Test Lab Game Loop y Edge-to-Edge ---
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -238,7 +278,14 @@ class MainActivity : FlutterActivity() {
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, RESUME_WATCHDOG_CHANNEL).setMethodCallHandler {
                 call, result ->
             if (call.method == "confirmResumeDrawn") {
+                if (watchdogPrefs.getBoolean(prefKeyRecreateAttempted, false)) {
+                    FirebaseCrashlytics.getInstance().log(
+                        "resume_watchdog: resume confirmed after recreate() — recovery succeeded"
+                    )
+                }
                 watchdogPrefs.edit().clear().apply()
+                resumeConfirmed = true
+                resumeWatchdogHandler.removeCallbacks(resumeTimeoutRunnable)
                 result.success(null)
             } else {
                 result.notImplemented()
@@ -274,6 +321,8 @@ class MainActivity : FlutterActivity() {
             .putBoolean(prefKeyPending, true)
             .putLong(prefKeyPendingSince, System.currentTimeMillis())
             .apply()
+
+        resumeWatchdogHandler.removeCallbacks(resumeTimeoutRunnable)
     }
 
     override fun onResume() {
@@ -290,6 +339,12 @@ class MainActivity : FlutterActivity() {
         Handler(Looper.getMainLooper()).postDelayed({
             flutterSurfaceView?.requestLayout()
         }, 1)
+
+        // Arm the live auto-recovery timeout for this resume cycle. Cancelled by
+        // confirmResumeDrawn() if a frame actually renders in time; otherwise fires
+        // recreate() once. See the "Live auto-recovery" comment above for context.
+        resumeConfirmed = false
+        resumeWatchdogHandler.postDelayed(resumeTimeoutRunnable, resumeConfirmTimeoutMs)
 
         // Dispatch any warm-start deep link now that the Flutter engine is in
         // "resumed" state and Navigator transitions will render correctly.

--- a/android/app/src/main/kotlin/com/develop4god/devocional_nuevo/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/develop4god/devocional_nuevo/MainActivity.kt
@@ -10,10 +10,20 @@ import android.os.Bundle
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import android.util.Log
 import androidx.core.view.WindowCompat
 import com.google.firebase.crashlytics.FirebaseCrashlytics // ¡Añade esta importación!
 
 class MainActivity : FlutterActivity() {
+
+    // Mirrors resume-watchdog breadcrumbs to logcat in addition to Crashlytics.
+    // Crashlytics.log() only uploads with the next crash/non-fatal report, so it's
+    // invisible in a live `flutter run`/logcat session — this makes the watchdog's
+    // otherwise-silent trigger/outcome observable while testing on a real device.
+    private fun logWatchdog(message: String) {
+        Log.d("ResumeWatchdog", message)
+        FirebaseCrashlytics.getInstance().log(message)
+    }
 
     // Method channels
     private val CRASHLYTICS_CHANNEL = "com.develop4god.devocional_nuevo/crashlytics"
@@ -85,25 +95,26 @@ class MainActivity : FlutterActivity() {
     private var resumeConfirmed = false
     private val resumeWatchdogHandler = Handler(Looper.getMainLooper())
     private val resumeTimeoutRunnable = Runnable {
-        if (!resumeConfirmed && !watchdogPrefs.getBoolean(prefKeyRecreateAttempted, false)) {
-            watchdogPrefs.edit().putBoolean(prefKeyRecreateAttempted, true).apply()
-            FirebaseCrashlytics.getInstance().log(
-                "resume_watchdog: triggered, resume not confirmed within ${resumeConfirmTimeoutMs}ms, calling recreate()"
-            )
-            // recreate() can throw if the activity is already finishing/destroyed by
-            // the time this delayed callback fires (e.g. user navigated away in the
-            // interim). Never let a failed recovery attempt crash the app outright —
-            // the existing reportStaleResumeMarkerIfAny() path still catches this case
-            // via ApplicationExitInfo on the next cold start if recovery didn't work.
-            try {
-                recreate()
-                FirebaseCrashlytics.getInstance().log("resume_watchdog: recreate() call returned normally")
-            } catch (e: Exception) {
-                FirebaseCrashlytics.getInstance().log(
-                    "resume_watchdog: recreate() threw: ${e.javaClass.simpleName}: ${e.message}"
-                )
-                FirebaseCrashlytics.getInstance().recordException(e)
-            }
+        if (resumeConfirmed) return@Runnable
+        if (watchdogPrefs.getBoolean(prefKeyRecreateAttempted, false)) {
+            logWatchdog("resume_watchdog: timeout fired again but recreate() already attempted this cycle — not looping")
+            return@Runnable
+        }
+        watchdogPrefs.edit().putBoolean(prefKeyRecreateAttempted, true).apply()
+        logWatchdog(
+            "resume_watchdog: triggered, resume not confirmed within ${resumeConfirmTimeoutMs}ms, calling recreate()"
+        )
+        // recreate() can throw if the activity is already finishing/destroyed by
+        // the time this delayed callback fires (e.g. user navigated away in the
+        // interim). Never let a failed recovery attempt crash the app outright —
+        // the existing reportStaleResumeMarkerIfAny() path still catches this case
+        // via ApplicationExitInfo on the next cold start if recovery didn't work.
+        try {
+            recreate()
+            logWatchdog("resume_watchdog: recreate() call returned normally")
+        } catch (e: Exception) {
+            logWatchdog("resume_watchdog: recreate() threw: ${e.javaClass.simpleName}: ${e.message}")
+            FirebaseCrashlytics.getInstance().recordException(e)
         }
     }
 
@@ -167,16 +178,23 @@ class MainActivity : FlutterActivity() {
 
         val pendingSinceMs = watchdogPrefs.getLong(prefKeyPendingSince, 0L)
         val staleForMs = if (pendingSinceMs > 0) System.currentTimeMillis() - pendingSinceMs else -1L
-        watchdogPrefs.edit().clear().apply()
+        // Clear only the staleness-tracking keys, not prefKeyRecreateAttempted: this
+        // runs on every cold start, including the one recreate() itself triggers when
+        // the live-recovery timeout fires. Wiping the whole prefs file here would erase
+        // the one-attempt guard on that exact cold start, letting onResume() re-arm the
+        // timeout and call recreate() again if the underlying freeze persists — an
+        // unbounded recreate loop instead of a single bounded attempt.
+        watchdogPrefs.edit()
+            .remove(prefKeyPending)
+            .remove(prefKeyPendingSince)
+            .apply()
 
         if (!likelyMatchesBlackScreenExit()) return
 
         FirebaseCrashlytics.getInstance().recordException(
             Exception("Resume never confirmed drawn before app restart (possible black-screen-on-resume)")
         )
-        FirebaseCrashlytics.getInstance().log(
-            "resume_watchdog: unconfirmed resume detected on cold start, staleForMs=$staleForMs"
-        )
+        logWatchdog("resume_watchdog: unconfirmed resume detected on cold start, staleForMs=$staleForMs")
     }
 
     // Returns true only if the most recent process exit reason plausibly
@@ -217,18 +235,14 @@ class MainActivity : FlutterActivity() {
                     // verbatim instead of silently lumping it in with the
                     // known-excluded cases, so an unexpected pattern is
                     // visible if it starts showing up in Crashlytics.
-                    FirebaseCrashlytics.getInstance().log(
-                        "resume_watchdog: unrecognized exit reason code=$lastReason"
-                    )
+                    logWatchdog("resume_watchdog: unrecognized exit reason code=$lastReason")
                     false
                 }
             }
         } catch (e: Exception) {
             // Never let a telemetry read failure affect startup; fail open
             // so the underlying signal still gets reported rather than lost.
-            FirebaseCrashlytics.getInstance().log(
-                "resume_watchdog: error reading exit reason: ${e.message}"
-            )
+            logWatchdog("resume_watchdog: error reading exit reason: ${e.message}")
             true
         }
     }
@@ -279,9 +293,7 @@ class MainActivity : FlutterActivity() {
                 call, result ->
             if (call.method == "confirmResumeDrawn") {
                 if (watchdogPrefs.getBoolean(prefKeyRecreateAttempted, false)) {
-                    FirebaseCrashlytics.getInstance().log(
-                        "resume_watchdog: resume confirmed after recreate() — recovery succeeded"
-                    )
+                    logWatchdog("resume_watchdog: resume confirmed after recreate() — recovery succeeded")
                 }
                 watchdogPrefs.edit().clear().apply()
                 resumeConfirmed = true


### PR DESCRIPTION
## Summary
- Production Crashlytics telemetry (573 affected users, broad OEM/Android-version spread, correlated with low free RAM ~1.67 GiB) confirmed the black-screen-on-resume freeze is a real, frequent failure — not a rare edge case.
- Adds a live auto-recovery path in `MainActivity.onResume()`: a timer on the Android platform thread (separate from Flutter's engine threads, so it keeps running even if Flutter itself is frozen) that calls `Activity.recreate()` once if `confirmResumeDrawn()` doesn't arrive within 3s.
- The recreate attempt is guarded via `SharedPreferences` (not a plain field, since `recreate()` can spin up a fresh `Activity` instance) to fire at most once per stuck cycle.
- Added Crashlytics logging + try/catch around the recovery flow so the full lifecycle is visible in production: trigger → `recreate()` outcome (success/threw) → whether the next resume confirmed drawn (proves recovery worked).
- The existing diagnostic-only `reportStaleResumeMarkerIfAny()` path (reports via `ApplicationExitInfo` on next cold start if the app was killed while still stuck) is unchanged and remains the fallback signal for when live recovery isn't enough.

## Context
No public precedent exists for this exact "watchdog + auto-recreate" pattern — researched via Flutter/engine issue trackers (flutter/flutter#147849, #106912, #145748, flutter/engine#52370). The likely mechanism is `ImageReaderSurfaceProducer`'s surface not reliably restoring after Android's `onTrimMemory`, which matches the low-RAM correlation in the data. This is a monitored rollout — success should be judged by whether `resume_watchdog: unconfirmed resume detected on cold start` non-fatals drop after shipping.

## Test plan
- [x] `dart format`, `flutter analyze --fatal-infos`, `dart fix --apply` all clean (via pre-push hook)
- [x] `:app:compileDebugKotlin` succeeds
- [x] Existing `test/unit/widgets/resume_watchdog_test.dart` passes unchanged (Dart-side `confirmResumeDrawn` channel call untouched)
- [ ] Monitor Crashlytics after rollout for recovery trigger/success rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)