### PR TITLE
Add update detection for downloaded Bible versions

### DIFF
--- a/bible_reader_core/lib/src/bible_reader_controller.dart
+++ b/bible_reader_core/lib/src/bible_reader_controller.dart
@@ -243,7 +243,23 @@ class BibleReaderController {
   /// updated fields (hasUpdate, remoteHash) that must overwrite the stale
   /// listed copy, not be discarded in favor of it.
   Future<void> switchVersion(BibleVersion newVersion) async {
-    if (newVersion.dbFileName == _state.selectedVersion?.dbFileName) return;
+    if (newVersion.dbFileName == _state.selectedVersion?.dbFileName) {
+      // Same file already selected — e.g. re-downloading the version the
+      // user is currently reading to apply an update. No DB
+      // re-initialization or reading-position reset is needed, but the
+      // listed entry's metadata (hasUpdate, remoteHash) must still be
+      // refreshed so a cleared update badge doesn't get lost.
+      _emit(
+        _state.copyWith(
+          availableVersions: _state.availableVersions
+              .map(
+                  (v) => v.dbFileName == newVersion.dbFileName ? newVersion : v)
+              .toList(),
+          selectedVersion: newVersion,
+        ),
+      );
+      return;
+    }
 
     _emit(_state.copyWith(isLoading: true));
 

--- a/bible_reader_core/lib/src/bible_reader_controller.dart
+++ b/bible_reader_core/lib/src/bible_reader_controller.dart
@@ -237,7 +237,11 @@ class BibleReaderController {
   /// [BibleReaderState.availableVersions] — e.g. it was just downloaded —
   /// it's appended, so the caller's version list reflects it as current
   /// immediately, without waiting for a fresh [availableVersions] to be
-  /// supplied from outside.
+  /// supplied from outside. If it's already listed, the existing entry is
+  /// replaced with [newVersion] rather than kept as-is — e.g. a
+  /// re-download to apply an update passes a fresh [newVersion] with
+  /// updated fields (hasUpdate, remoteHash) that must overwrite the stale
+  /// listed copy, not be discarded in favor of it.
   Future<void> switchVersion(BibleVersion newVersion) async {
     if (newVersion.dbFileName == _state.selectedVersion?.dbFileName) return;
 
@@ -251,6 +255,8 @@ class BibleReaderController {
         .any((v) => v.dbFileName == newVersion.dbFileName);
     final availableVersions = alreadyListed
         ? _state.availableVersions
+            .map((v) => v.dbFileName == newVersion.dbFileName ? newVersion : v)
+            .toList()
         : [..._state.availableVersions, newVersion];
 
     _emit(

--- a/bible_reader_core/lib/src/bible_version.dart
+++ b/bible_reader_core/lib/src/bible_version.dart
@@ -13,6 +13,17 @@ class BibleVersion {
   /// covered by `CopyrightUtils`'s bundled-version lookup. Null for all
   /// bundled/asset versions.
   final String? disclaimer;
+
+  /// True when this version is already downloaded but the remote index's
+  /// content hash for it no longer matches the hash stored at download
+  /// time — i.e. a newer file is available to re-download.
+  final bool hasUpdate;
+
+  /// Content fingerprint of this version's remote .gz file, as reported by
+  /// the index at fetch/download time. Used to detect future updates by
+  /// comparison; null for bundled/asset versions or an index that predates
+  /// this field.
+  final String? remoteHash;
   BibleDbService? service;
 
   BibleVersion({
@@ -24,6 +35,8 @@ class BibleVersion {
     this.isDownloaded = true,
     this.remoteUrl,
     this.disclaimer,
+    this.hasUpdate = false,
+    this.remoteHash,
     this.service,
   });
 
@@ -41,6 +54,8 @@ class BibleVersion {
     bool? isDownloaded,
     String? remoteUrl,
     String? disclaimer,
+    bool? hasUpdate,
+    String? remoteHash,
     BibleDbService? service,
   }) {
     return BibleVersion(
@@ -52,6 +67,8 @@ class BibleVersion {
       isDownloaded: isDownloaded ?? this.isDownloaded,
       remoteUrl: remoteUrl ?? this.remoteUrl,
       disclaimer: disclaimer ?? this.disclaimer,
+      hasUpdate: hasUpdate ?? this.hasUpdate,
+      remoteHash: remoteHash ?? this.remoteHash,
       service: service ?? this.service,
     );
   }

--- a/bible_reader_core/lib/src/bible_version_registry.dart
+++ b/bible_reader_core/lib/src/bible_version_registry.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:flutter/services.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
@@ -131,9 +132,24 @@ class BibleVersionRegistry {
       final Map<String, dynamic> names = namesJson != null
           ? jsonDecode(namesJson) as Map<String, dynamic>
           : {};
+      debugPrint(
+        '[BibleVersionRegistry] getDownloadedRemoteVersionsForLanguage('
+        '$languageCode) namesJson=$namesJson',
+      );
 
       final suffix = '_$languageCode.SQLite3';
       final List<BibleVersion> result = [];
+
+      final allFiles = dir
+          .listSync()
+          .whereType<File>()
+          .map((f) => basename(f.path))
+          .toList();
+      debugPrint(
+        '[BibleVersionRegistry] documents dir files matching *$suffix: '
+        '${allFiles.where((f) => f.endsWith(suffix)).toList()} '
+        '(bundledFileNames=$bundledFileNames)',
+      );
 
       for (final entity in dir.listSync()) {
         if (entity is! File) continue;

--- a/bible_reader_core/lib/src/bible_version_registry.dart
+++ b/bible_reader_core/lib/src/bible_version_registry.dart
@@ -142,15 +142,18 @@ class BibleVersionRegistry {
         if (bundledFileNames.contains(fileName)) continue;
 
         // Entries may be a plain display-name string (legacy) or a
-        // {"name": ..., "disclaimer": ...} map (current format).
+        // {"name": ..., "disclaimer": ..., "hash": ...} map (current
+        // format).
         final stored = names[fileName];
         String displayName = fileName;
         String? disclaimer;
+        String? hash;
         if (stored is String) {
           displayName = stored;
         } else if (stored is Map) {
           displayName = stored['name'] as String? ?? fileName;
           disclaimer = stored['disclaimer'] as String?;
+          hash = stored['hash'] as String?;
         }
 
         result.add(
@@ -162,6 +165,7 @@ class BibleVersionRegistry {
             dbFileName: fileName,
             isDownloaded: true,
             disclaimer: disclaimer,
+            remoteHash: hash,
           ),
         );
       }

--- a/bible_reader_core/test/bible_reader_controller_test.dart
+++ b/bible_reader_core/test/bible_reader_controller_test.dart
@@ -8,6 +8,38 @@ import 'package:bible_reader_core/src/bible_version.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+/// A no-op BibleDbService for switchVersion tests — initDb doesn't touch a
+/// real asset/file, and the book/chapter queries return just enough data
+/// for switchVersion's post-switch _loadChapterData() to complete.
+class _FakeBibleDbService extends BibleDbService {
+  @override
+  Future<void> initDb(String dbAssetPath, String dbName) async {}
+
+  @override
+  Future<List<Map<String, dynamic>>> getAllBooks() async => [
+        {'book_number': 1, 'short_name': 'GN', 'long_name': 'Genesis'},
+      ];
+
+  @override
+  Future<int> getMaxChapter(int bookNumber) async => 50;
+
+  @override
+  Future<List<Map<String, dynamic>>> getChapterVerses(
+    int bookNumber,
+    int chapter,
+  ) async =>
+      [
+        {'verse': 1, 'text': 'In the beginning...'},
+      ];
+
+  @override
+  Future<List<Map<String, dynamic>>> getSectionTitles({
+    required int bookNumber,
+    required int chapter,
+  }) async =>
+      [];
+}
+
 void main() {
   late BibleReaderController controller;
   late BibleReaderService readerService;
@@ -515,6 +547,95 @@ void main() {
       final state = controller.state;
       controller.toggleFontControls();
       expect(identical(state, controller.state), false);
+    });
+  });
+
+  group('BibleReaderController switchVersion Tests', () {
+    BibleVersion versionWith({
+      required String dbFileName,
+      bool hasUpdate = false,
+      String? remoteHash,
+    }) {
+      return BibleVersion(
+        name: dbFileName,
+        language: 'Español',
+        languageCode: 'es',
+        assetPath: 'assets/bible/$dbFileName',
+        dbFileName: dbFileName,
+        hasUpdate: hasUpdate,
+        remoteHash: remoteHash,
+        service: _FakeBibleDbService(),
+      );
+    }
+
+    test(
+        'replaces a stale already-listed entry with the fresh copy when '
+        'switching to a different version', () async {
+      final staleA = versionWith(dbFileName: 'A.SQLite3', hasUpdate: true);
+      final freshB = versionWith(dbFileName: 'B.SQLite3');
+      // _initializeVersionService also calls readerService.dbService.initDb
+      // — a real BibleDbService there would hit path_provider, which needs
+      // a Flutter binding this test doesn't set up. Use the fake here too.
+      final fakeReaderService = BibleReaderService(
+        dbService: _FakeBibleDbService(),
+        positionService: BibleReadingPositionService(),
+      );
+      controller = BibleReaderController(
+        allVersions: [staleA, freshB],
+        readerService: fakeReaderService,
+        preferencesService: preferencesService,
+        initialState: BibleReaderState(
+          availableVersions: [staleA, freshB],
+          selectedVersion: freshB,
+        ),
+      );
+
+      final freshA = versionWith(dbFileName: 'A.SQLite3', hasUpdate: false);
+      await controller.switchVersion(freshA);
+
+      final listed = controller.state.availableVersions
+          .firstWhere((v) => v.dbFileName == 'A.SQLite3');
+      expect(listed.hasUpdate, isFalse);
+      expect(controller.state.selectedVersion?.dbFileName, 'A.SQLite3');
+    });
+
+    test(
+        'refreshes the listed entry when re-downloading the ALREADY '
+        'SELECTED version, without resetting reading position', () async {
+      final staleSelected =
+          versionWith(dbFileName: 'A.SQLite3', hasUpdate: true);
+      controller = BibleReaderController(
+        allVersions: [staleSelected],
+        readerService: readerService,
+        preferencesService: preferencesService,
+        initialState: BibleReaderState(
+          availableVersions: [staleSelected],
+          selectedVersion: staleSelected,
+          selectedBookName: 'GN',
+          selectedBookNumber: 1,
+          selectedChapter: 3,
+          selectedVerse: 5,
+        ),
+      );
+
+      final freshSelected =
+          versionWith(dbFileName: 'A.SQLite3', hasUpdate: false);
+      await controller.switchVersion(freshSelected);
+
+      final listed = controller.state.availableVersions
+          .firstWhere((v) => v.dbFileName == 'A.SQLite3');
+      expect(
+        listed.hasUpdate,
+        isFalse,
+        reason: 'the stale hasUpdate: true copy must not survive a '
+            'redownload of the currently-selected version',
+      );
+      expect(controller.state.selectedVersion?.hasUpdate, isFalse);
+      // Reading position must be preserved — this is a metadata refresh,
+      // not a real version switch.
+      expect(controller.state.selectedBookName, 'GN');
+      expect(controller.state.selectedChapter, 3);
+      expect(controller.state.selectedVerse, 5);
     });
   });
 }

--- a/bible_reader_core/test/bible_version_registry_test.dart
+++ b/bible_reader_core/test/bible_version_registry_test.dart
@@ -126,6 +126,49 @@ void main() {
       );
     });
 
+    test('reads hash from the current map-shaped stored entry', () async {
+      final file = File('${tempDir.path}/RVR1909_es.SQLite3');
+      await file.writeAsBytes([1, 2, 3]);
+
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        'bible_remote_version_names',
+        jsonEncode({
+          'RVR1909_es.SQLite3': {
+            'name': 'Reina-Valera 1909 (con Números Strong)',
+            'hash': 'abc123def456',
+          },
+        }),
+      );
+
+      final result =
+          await BibleVersionRegistry.getDownloadedRemoteVersionsForLanguage(
+        'es',
+      );
+
+      expect(result, hasLength(1));
+      expect(result.first.remoteHash, 'abc123def456');
+    });
+
+    test('leaves hash null for legacy plain-string stored entries', () async {
+      final file = File('${tempDir.path}/CUSTOM_fr.SQLite3');
+      await file.writeAsBytes([1, 2, 3]);
+
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        'bible_remote_version_names',
+        jsonEncode({'CUSTOM_fr.SQLite3': 'Custom French Version'}),
+      );
+
+      final result =
+          await BibleVersionRegistry.getDownloadedRemoteVersionsForLanguage(
+        'fr',
+      );
+
+      expect(result, hasLength(1));
+      expect(result.first.remoteHash, isNull);
+    });
+
     test('getVersionsForLanguage includes downloaded remote versions',
         () async {
       final file = File('${tempDir.path}/CUSTOM_fr.SQLite3');

--- a/i18n/ar.json
+++ b/i18n/ar.json
@@ -466,7 +466,8 @@
   },
   "bubble_constants": {
     "new_feature": "جديد",
-    "updated_feature": "مُحدَّث"
+    "updated_feature": "مُحدَّث",
+    "update_available": "تحديث"
   },
   "backup": {
     "title": "المزامنة والحماية",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -466,7 +466,8 @@
   },
   "bubble_constants": {
     "new_feature": "Neu",
-    "updated_feature": "Aktualisiert"
+    "updated_feature": "Aktualisiert",
+    "update_available": "Aktualisieren"
   },
   "backup": {
     "title": "Synchronisierung und Schutz",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -466,7 +466,8 @@
   },
   "bubble_constants": {
     "new_feature": "New",
-    "updated_feature": "Updated"
+    "updated_feature": "Updated",
+    "update_available": "Update"
   },
   "backup": {
     "title": "Sync and Protection",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -466,7 +466,8 @@
   },
   "bubble_constants": {
     "new_feature": "Nuevo",
-    "updated_feature": "Actualizado"
+    "updated_feature": "Actualizado",
+    "update_available": "Actualizar"
   },
   "backup": {
     "title": "Sincronización y protección",

--- a/i18n/fil.json
+++ b/i18n/fil.json
@@ -466,7 +466,8 @@
   },
   "bubble_constants": {
     "new_feature": "Bago",
-    "updated_feature": "Na-update"
+    "updated_feature": "Na-update",
+    "update_available": "I-update"
   },
   "backup": {
     "title": "Pag-sync at Proteksyon",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -466,7 +466,8 @@
   },
   "bubble_constants": {
     "new_feature": "Nouveau",
-    "updated_feature": "Mise à jour"
+    "updated_feature": "Mise à jour",
+    "update_available": "Mettre à jour"
   },
   "backup": {
     "title": "Synchronisation et protection",

--- a/i18n/hi.json
+++ b/i18n/hi.json
@@ -466,7 +466,8 @@
   },
   "bubble_constants": {
     "new_feature": "नया",
-    "updated_feature": "अद्यतन"
+    "updated_feature": "अद्यतन",
+    "update_available": "अद्यतन करें"
   },
   "backup": {
     "title": "बैकअप",

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -466,7 +466,8 @@
   },
   "bubble_constants": {
     "new_feature": "新機能",
-    "updated_feature": "更新"
+    "updated_feature": "更新",
+    "update_available": "更新する"
   },
   "backup": {
     "title": "バックアップ",

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -466,7 +466,8 @@
   },
   "bubble_constants": {
     "new_feature": "Novo",
-    "updated_feature": "Actualização"
+    "updated_feature": "Actualização",
+    "update_available": "Atualizar"
   },
   "backup": {
     "title": "Backup",

--- a/i18n/zh.json
+++ b/i18n/zh.json
@@ -466,7 +466,8 @@
   },
   "bubble_constants": {
     "new_feature": "新",
-    "updated_feature": "更新"
+    "updated_feature": "更新",
+    "update_available": "更新"
   },
   "backup": {
     "title": "同步 和 保护",

--- a/lib/models/remote_bible_index.dart
+++ b/lib/models/remote_bible_index.dart
@@ -48,11 +48,17 @@ class RemoteBibleVersionEntry {
   /// most entries.
   final String? disclaimer;
 
+  /// Content fingerprint of the version's .gz file, used to detect when an
+  /// already-downloaded version has a newer file available. Absent on
+  /// index entries generated before this field existed.
+  final String? hash;
+
   RemoteBibleVersionEntry({
     required this.name,
     required this.file,
     required this.url,
     this.disclaimer,
+    this.hash,
   });
 
   factory RemoteBibleVersionEntry.fromJson(Map<String, dynamic> json) {
@@ -61,6 +67,7 @@ class RemoteBibleVersionEntry {
       file: json['file'] as String,
       url: json['url'] as String,
       disclaimer: json['disclaimer'] as String?,
+      hash: json['hash'] as String?,
     );
   }
 }

--- a/lib/pages/bible_reader_page.dart
+++ b/lib/pages/bible_reader_page.dart
@@ -1163,14 +1163,6 @@ class _BibleReaderPageState extends State<BibleReaderPage> {
                               ? versionsState.downloadStatuses
                               : const <String, VersionDownloadStatus>{};
 
-                      debugPrint(
-                        '[BibleReaderDrawer build] versionsState=$versionsState '
-                        'availableVersions=${state.availableVersions.map((v) => v.dbFileName).toList()} '
-                        'downloadedFileNames=$downloadedFileNames '
-                        'downloadableVersions=${downloadableVersions.map((v) => v.dbFileName).toList()} '
-                        'updatedFileNames=${updatedVersionsByFileName.keys.toList()}',
-                      );
-
                       return BibleReaderDrawer(
                         availableVersions: availableVersions,
                         selectedVersion: state.selectedVersion,

--- a/lib/pages/bible_reader_page.dart
+++ b/lib/pages/bible_reader_page.dart
@@ -1142,17 +1142,21 @@ class _BibleReaderPageState extends State<BibleReaderPage> {
                       // Downloaded versions the index reports as changed
                       // since download — surfaced as an update badge on
                       // the existing availableVersions entry rather than a
-                      // separate downloadable tile.
-                      final updatedFileNames = remoteVersions
-                          .where((v) =>
-                              v.hasUpdate &&
+                      // separate downloadable tile. Keyed by dbFileName so
+                      // the full remote entry (with remoteUrl/remoteHash,
+                      // which the disk-scanned availableVersions entry
+                      // never has) can be used for the redownload — not
+                      // just its hasUpdate flag copied over, which would
+                      // leave remoteUrl null and make the redownload fail.
+                      final updatedVersionsByFileName = {
+                        for (final v in remoteVersions)
+                          if (v.hasUpdate &&
                               downloadedFileNames.contains(v.dbFileName))
-                          .map((v) => v.dbFileName)
-                          .toSet();
+                            v.dbFileName: v,
+                      };
                       final availableVersions = state.availableVersions
-                          .map((v) => updatedFileNames.contains(v.dbFileName)
-                              ? v.copyWith(hasUpdate: true)
-                              : v)
+                          .map((v) =>
+                              updatedVersionsByFileName[v.dbFileName] ?? v)
                           .toList();
                       final downloadStatuses =
                           versionsState is BibleVersionsLoaded
@@ -1164,7 +1168,7 @@ class _BibleReaderPageState extends State<BibleReaderPage> {
                         'availableVersions=${state.availableVersions.map((v) => v.dbFileName).toList()} '
                         'downloadedFileNames=$downloadedFileNames '
                         'downloadableVersions=${downloadableVersions.map((v) => v.dbFileName).toList()} '
-                        'updatedFileNames=$updatedFileNames',
+                        'updatedFileNames=${updatedVersionsByFileName.keys.toList()}',
                       );
 
                       return BibleReaderDrawer(

--- a/lib/pages/bible_reader_page.dart
+++ b/lib/pages/bible_reader_page.dart
@@ -975,24 +975,13 @@ class _BibleReaderPageState extends State<BibleReaderPage> {
         // before onVersionsMayHaveChanged() below remounts this page with a
         // fresh key — otherwise the remount restores the previous version.
         // version may be the stale pre-download copy (e.g. a redownload
-        // triggered from the update badge): hasUpdate/remoteHash must be
-        // cleared so the controller's availableVersions doesn't keep
-        // showing an update as still pending for the file just downloaded.
-        // copyWith can't express "clear remoteHash" (its null-coalescing
-        // pattern treats a null argument as "keep existing"), so build the
-        // corrected version directly instead.
+        // triggered from the update badge): hasUpdate must be cleared so
+        // the controller's availableVersions doesn't keep showing an
+        // update as still pending for the file just downloaded. remoteHash
+        // is intentionally carried through as-is, since the file on disk
+        // now matches it.
         await _controller.switchVersion(
-          BibleVersion(
-            name: version.name,
-            language: version.language,
-            languageCode: version.languageCode,
-            assetPath: version.assetPath,
-            dbFileName: version.dbFileName,
-            isDownloaded: true,
-            remoteUrl: version.remoteUrl,
-            disclaimer: version.disclaimer,
-            service: version.service,
-          ),
+          version.copyWith(isDownloaded: true, hasUpdate: false),
         );
         widget.onVersionsMayHaveChanged?.call();
         if (!context.mounted) return;

--- a/lib/pages/bible_reader_page.dart
+++ b/lib/pages/bible_reader_page.dart
@@ -1123,13 +1123,29 @@ class _BibleReaderPageState extends State<BibleReaderPage> {
                       final downloadedFileNames = state.availableVersions
                           .map((v) => v.dbFileName)
                           .toSet();
-                      final downloadableVersions = versionsState
-                              is BibleVersionsLoaded
-                          ? versionsState.remoteVersions
-                              .where((v) =>
-                                  !downloadedFileNames.contains(v.dbFileName))
-                              .toList()
-                          : const <BibleVersion>[];
+                      final remoteVersions =
+                          versionsState is BibleVersionsLoaded
+                              ? versionsState.remoteVersions
+                              : const <BibleVersion>[];
+                      final downloadableVersions = remoteVersions
+                          .where((v) =>
+                              !downloadedFileNames.contains(v.dbFileName))
+                          .toList();
+                      // Downloaded versions the index reports as changed
+                      // since download — surfaced as an update badge on
+                      // the existing availableVersions entry rather than a
+                      // separate downloadable tile.
+                      final updatedFileNames = remoteVersions
+                          .where((v) =>
+                              v.hasUpdate &&
+                              downloadedFileNames.contains(v.dbFileName))
+                          .map((v) => v.dbFileName)
+                          .toSet();
+                      final availableVersions = state.availableVersions
+                          .map((v) => updatedFileNames.contains(v.dbFileName)
+                              ? v.copyWith(hasUpdate: true)
+                              : v)
+                          .toList();
                       final downloadStatuses =
                           versionsState is BibleVersionsLoaded
                               ? versionsState.downloadStatuses
@@ -1139,11 +1155,12 @@ class _BibleReaderPageState extends State<BibleReaderPage> {
                         '[BibleReaderDrawer build] versionsState=$versionsState '
                         'availableVersions=${state.availableVersions.map((v) => v.dbFileName).toList()} '
                         'downloadedFileNames=$downloadedFileNames '
-                        'downloadableVersions=${downloadableVersions.map((v) => v.dbFileName).toList()}',
+                        'downloadableVersions=${downloadableVersions.map((v) => v.dbFileName).toList()} '
+                        'updatedFileNames=$updatedFileNames',
                       );
 
                       return BibleReaderDrawer(
-                        availableVersions: state.availableVersions,
+                        availableVersions: availableVersions,
                         selectedVersion: state.selectedVersion,
                         downloadableVersions: downloadableVersions,
                         downloadStatuses: downloadStatuses,

--- a/lib/pages/bible_reader_page.dart
+++ b/lib/pages/bible_reader_page.dart
@@ -974,7 +974,26 @@ class _BibleReaderPageState extends State<BibleReaderPage> {
         // Switch first, so the new version's reading position is saved
         // before onVersionsMayHaveChanged() below remounts this page with a
         // fresh key — otherwise the remount restores the previous version.
-        await _controller.switchVersion(version);
+        // version may be the stale pre-download copy (e.g. a redownload
+        // triggered from the update badge): hasUpdate/remoteHash must be
+        // cleared so the controller's availableVersions doesn't keep
+        // showing an update as still pending for the file just downloaded.
+        // copyWith can't express "clear remoteHash" (its null-coalescing
+        // pattern treats a null argument as "keep existing"), so build the
+        // corrected version directly instead.
+        await _controller.switchVersion(
+          BibleVersion(
+            name: version.name,
+            language: version.language,
+            languageCode: version.languageCode,
+            assetPath: version.assetPath,
+            dbFileName: version.dbFileName,
+            isDownloaded: true,
+            remoteUrl: version.remoteUrl,
+            disclaimer: version.disclaimer,
+            service: version.service,
+          ),
+        );
         widget.onVersionsMayHaveChanged?.call();
         if (!context.mounted) return;
         AppSnackBar.show(

--- a/lib/repositories/bible_version_repository.dart
+++ b/lib/repositories/bible_version_repository.dart
@@ -101,11 +101,17 @@ class BibleVersionRepository implements IBibleVersionRepository {
       }
 
       final isDownloaded = downloadedRemoteHashes.containsKey(code);
-      // Also treated as "up to date" when both sides are null — a version
-      // downloaded before the hash field existed, compared against an
-      // index that (for whatever reason) still lacks one, must not be
-      // flagged hasUpdate: true on a false positive.
-      if (isDownloaded && downloadedRemoteHashes[code] == versionEntry.hash) {
+      final storedHash = downloadedRemoteHashes[code];
+      // Treated as "up to date" when hashes match, or when the stored side
+      // is null — a version downloaded before the hash field existed has
+      // no fingerprint to compare, so there's no way to tell whether the
+      // remote file actually changed since. Flagging hasUpdate: true here
+      // would be a false positive for every pre-existing download on this
+      // feature's rollout, not a real update; treat it as a silent
+      // baseline instead of nagging. A subsequent real content change is
+      // caught once this version's stored hash is set (at next download).
+      if (isDownloaded &&
+          (storedHash == null || storedHash == versionEntry.hash)) {
         debugPrint(
           '[BibleVersionRepository] skipping $code — downloaded and '
           'up to date',

--- a/lib/repositories/bible_version_repository.dart
+++ b/lib/repositories/bible_version_repository.dart
@@ -74,12 +74,17 @@ class BibleVersionRepository implements IBibleVersionRepository {
         .where((v) => v.assetPath.isNotEmpty)
         .map((v) => v.dbFileName.split('_').first)
         .toSet();
-    // Already-downloaded remote codes, keyed to their stored content hash
-    // so an index hash mismatch can be surfaced as an available update
-    // instead of the version being silently omitted forever.
-    final downloadedRemoteHashes = {
+    // Already-downloaded remote versions, keyed by code, so a hash
+    // mismatch can be surfaced as an available update instead of the
+    // version being silently omitted forever, and so a legacy download
+    // (no stored hash yet) can be backfilled with a baseline below.
+    final downloadedRemoteVersions = {
       for (final v in bundledVersions.where((v) => v.assetPath.isEmpty))
-        v.dbFileName.split('_').first: v.remoteHash,
+        v.dbFileName.split('_').first: v,
+    };
+    final downloadedRemoteHashes = {
+      for (final entry in downloadedRemoteVersions.entries)
+        entry.key: entry.value.remoteHash,
     };
     debugPrint(
       '[BibleVersionRepository] asset codes for $languageCode: $assetCodes; '
@@ -102,21 +107,38 @@ class BibleVersionRepository implements IBibleVersionRepository {
 
       final isDownloaded = downloadedRemoteHashes.containsKey(code);
       final storedHash = downloadedRemoteHashes[code];
-      // Treated as "up to date" when hashes match, or when the stored side
-      // is null — a version downloaded before the hash field existed has
-      // no fingerprint to compare, so there's no way to tell whether the
-      // remote file actually changed since. Flagging hasUpdate: true here
-      // would be a false positive for every pre-existing download on this
-      // feature's rollout, not a real update; treat it as a silent
-      // baseline instead of nagging. A subsequent real content change is
-      // caught once this version's stored hash is set (at next download).
-      if (isDownloaded &&
-          (storedHash == null || storedHash == versionEntry.hash)) {
+
+      if (isDownloaded) {
+        debugPrint(
+          '[BibleVersionRepository] CHECK $code — '
+          'storedHash=$storedHash, indexHash=${versionEntry.hash}',
+        );
+      }
+
+      // Treated as "up to date" only when hashes match, or when both sides
+      // are null (no hash available anywhere to compare). A null stored
+      // hash is NOT assumed safe to backfill from the current index: the
+      // index may have already moved past the file actually on disk (the
+      // file changed between original download and this feature
+      // shipping), so silently adopting "whatever the index says now" as
+      // the baseline would wrongly mark a genuinely outdated file as up
+      // to date, with no way to ever detect the missed update. A legacy
+      // download with no stored hash always surfaces as hasUpdate: true
+      // against a non-null index hash, forcing one real redownload that
+      // correctly establishes a trustworthy hash going forward.
+      if (isDownloaded && (storedHash == versionEntry.hash)) {
         debugPrint(
           '[BibleVersionRepository] skipping $code — downloaded and '
-          'up to date',
+          'up to date (storedHash=$storedHash, indexHash=${versionEntry.hash})',
         );
         continue;
+      }
+
+      if (isDownloaded) {
+        debugPrint(
+          '[BibleVersionRepository] $code has an update — '
+          'storedHash=$storedHash, indexHash=${versionEntry.hash}',
+        );
       }
 
       // A debug-branch index still points its own `url` field at `main`, so
@@ -266,6 +288,16 @@ class BibleVersionRepository implements IBibleVersionRepository {
   /// rest of the app session or across restarts. An ETag makes repeat calls
   /// cheap — the server returns 304 with no body when nothing changed, so
   /// this is not a full re-download on every drawer open.
+  /// Debug-only: prints the parsed LBLA/es hash from [index], so a device
+  /// log can be compared directly against the hash currently live on
+  /// GitHub without needing shell access to the device's SharedPreferences.
+  void _debugPrintLblaHash(String label, RemoteBibleIndex index) {
+    final lbla = index.languages['es']?.versions['LBLA'];
+    debugPrint(
+      '[BibleVersionRepository] $label — parsed LBLA hash=${lbla?.hash}',
+    );
+  }
+
   Future<RemoteBibleIndex> _fetchIndex(String branch) async {
     final prefs = await SharedPreferences.getInstance();
     final cacheKey = '$_indexCacheKeyPrefix$branch';
@@ -274,21 +306,31 @@ class BibleVersionRepository implements IBibleVersionRepository {
 
     try {
       final url = Constants.getBibleVersionsIndexUrl();
+      debugPrint(
+        '[BibleVersionRepository] _fetchIndex GET $url '
+        'If-None-Match=$cachedEtag',
+      );
       final request = http.Request('GET', Uri.parse(url));
       if (cachedEtag != null) {
         request.headers['If-None-Match'] = cachedEtag;
       }
       final streamedResponse = await httpClient.send(request);
       final response = await http.Response.fromStream(streamedResponse);
+      debugPrint(
+        '[BibleVersionRepository] _fetchIndex response status='
+        '${response.statusCode} etag=${response.headers['etag']}',
+      );
 
       if (response.statusCode == 304) {
         debugPrint(
             '[BibleVersionRepository] index unchanged (304), using cache');
         final cached = prefs.getString(cacheKey);
         if (cached != null) {
-          return RemoteBibleIndex.fromJson(
+          final index = RemoteBibleIndex.fromJson(
             jsonDecode(cached) as Map<String, dynamic>,
           );
+          _debugPrintLblaHash('304 cached body', index);
+          return index;
         }
         // No cached body despite a cached ETag — fall through to error path.
         throw Exception('304 received but no cached body for $cacheKey');
@@ -303,9 +345,11 @@ class BibleVersionRepository implements IBibleVersionRepository {
           await prefs.remove(etagKey);
         }
         debugPrint('[BibleVersionRepository] index fetched fresh (200)');
-        return RemoteBibleIndex.fromJson(
+        final index = RemoteBibleIndex.fromJson(
           jsonDecode(response.body) as Map<String, dynamic>,
         );
+        _debugPrintLblaHash('200 fresh body', index);
+        return index;
       }
 
       throw Exception('Server error: ${response.statusCode}');
@@ -314,9 +358,11 @@ class BibleVersionRepository implements IBibleVersionRepository {
           '[BibleVersionRepository] index fetch failed: $e — falling back to cache');
       final cached = prefs.getString(cacheKey);
       if (cached != null) {
-        return RemoteBibleIndex.fromJson(
+        final index = RemoteBibleIndex.fromJson(
           jsonDecode(cached) as Map<String, dynamic>,
         );
+        _debugPrintLblaHash('error-fallback cached body', index);
+        return index;
       }
       rethrow;
     }

--- a/lib/repositories/bible_version_repository.dart
+++ b/lib/repositories/bible_version_repository.dart
@@ -101,6 +101,10 @@ class BibleVersionRepository implements IBibleVersionRepository {
       }
 
       final isDownloaded = downloadedRemoteHashes.containsKey(code);
+      // Also treated as "up to date" when both sides are null — a version
+      // downloaded before the hash field existed, compared against an
+      // index that (for whatever reason) still lacks one, must not be
+      // flagged hasUpdate: true on a false positive.
       if (isDownloaded && downloadedRemoteHashes[code] == versionEntry.hash) {
         debugPrint(
           '[BibleVersionRepository] skipping $code — downloaded and '

--- a/lib/repositories/bible_version_repository.dart
+++ b/lib/repositories/bible_version_repository.dart
@@ -64,11 +64,26 @@ class BibleVersionRepository implements IBibleVersionRepository {
 
     final bundledVersions =
         await BibleVersionRegistry.getVersionsForLanguage(languageCode);
-    final bundledCodes =
-        bundledVersions.map((v) => v.dbFileName.split('_').first).toSet();
+    // Shipped-as-asset entries have a non-empty assetPath (see
+    // BibleVersionRegistry.getVersionsForLanguage); downloaded remote
+    // entries have an empty one. Neither has remoteUrl set at this point,
+    // so isRemote can't be used to tell them apart here.
+    // Shipped-as-asset codes are never re-offered — asset updates ship via
+    // app updates, not this download flow.
+    final assetCodes = bundledVersions
+        .where((v) => v.assetPath.isNotEmpty)
+        .map((v) => v.dbFileName.split('_').first)
+        .toSet();
+    // Already-downloaded remote codes, keyed to their stored content hash
+    // so an index hash mismatch can be surfaced as an available update
+    // instead of the version being silently omitted forever.
+    final downloadedRemoteHashes = {
+      for (final v in bundledVersions.where((v) => v.assetPath.isEmpty))
+        v.dbFileName.split('_').first: v.remoteHash,
+    };
     debugPrint(
-      '[BibleVersionRepository] bundled/downloaded codes for '
-      '$languageCode: $bundledCodes',
+      '[BibleVersionRepository] asset codes for $languageCode: $assetCodes; '
+      'downloaded remote codes: ${downloadedRemoteHashes.keys}',
     );
 
     final onMain = branch == 'main';
@@ -78,9 +93,18 @@ class BibleVersionRepository implements IBibleVersionRepository {
       final code = entry.key;
       final versionEntry = entry.value;
 
-      if (bundledCodes.contains(code)) {
+      if (assetCodes.contains(code)) {
         debugPrint(
-          '[BibleVersionRepository] skipping $code — already bundled/downloaded',
+          '[BibleVersionRepository] skipping $code — bundled as app asset',
+        );
+        continue;
+      }
+
+      final isDownloaded = downloadedRemoteHashes.containsKey(code);
+      if (isDownloaded && downloadedRemoteHashes[code] == versionEntry.hash) {
+        debugPrint(
+          '[BibleVersionRepository] skipping $code — downloaded and '
+          'up to date',
         );
         continue;
       }
@@ -102,9 +126,11 @@ class BibleVersionRepository implements IBibleVersionRepository {
           languageCode: languageCode,
           assetPath: '',
           dbFileName: versionEntry.file.replaceAll('.gz', ''),
-          isDownloaded: false,
+          isDownloaded: isDownloaded,
           remoteUrl: url,
           disclaimer: versionEntry.disclaimer,
+          hasUpdate: isDownloaded,
+          remoteHash: versionEntry.hash,
         ),
       );
     }
@@ -186,6 +212,7 @@ class BibleVersionRepository implements IBibleVersionRepository {
       version.dbFileName,
       version.name,
       version.disclaimer,
+      version.remoteHash,
     );
 
     if (contentLength != null && contentLength > 0) {
@@ -193,21 +220,22 @@ class BibleVersionRepository implements IBibleVersionRepository {
     }
   }
 
-  /// Persists the display name (and optional copyright disclaimer) for a
-  /// downloaded remote version, keyed by its dbFileName, in the
-  /// `bible_remote_version_names` SharedPreferences map.
+  /// Persists the display name (and optional copyright disclaimer and
+  /// content hash) for a downloaded remote version, keyed by its
+  /// dbFileName, in the `bible_remote_version_names` SharedPreferences map.
   /// [BibleVersionRegistry.getDownloadedRemoteVersionsForLanguage] reads
   /// this map to label downloaded remote versions — this repository owns
   /// writing it, since it owns the download side-effect that produces the
   /// file in the first place (SRP).
   ///
   /// Existing entries were plain `dbFileName: displayName` strings; new
-  /// entries are stored as `{"name": ..., "disclaimer": ...}` so old data
-  /// keeps parsing without migration.
+  /// entries are stored as `{"name": ..., "disclaimer": ..., "hash": ...}`
+  /// so old data keeps parsing without migration.
   Future<void> _saveDownloadedVersionName(
     String dbFileName,
     String displayName,
     String? disclaimer,
+    String? hash,
   ) async {
     final prefs = await SharedPreferences.getInstance();
     final existingJson = prefs.getString(_remoteVersionNamesPrefKey);
@@ -217,6 +245,7 @@ class BibleVersionRepository implements IBibleVersionRepository {
     names[dbFileName] = {
       'name': displayName,
       if (disclaimer != null) 'disclaimer': disclaimer,
+      if (hash != null) 'hash': hash,
     };
     await prefs.setString(_remoteVersionNamesPrefKey, jsonEncode(names));
   }

--- a/lib/repositories/bible_version_repository.dart
+++ b/lib/repositories/bible_version_repository.dart
@@ -180,6 +180,10 @@ class BibleVersionRepository implements IBibleVersionRepository {
     void Function(double? progress)? onProgress,
   }) async {
     final url = version.remoteUrl;
+    debugPrint(
+      '[BibleVersionRepository] downloadVersion(${version.dbFileName}) '
+      'starting — url=$url incomingRemoteHash=${version.remoteHash}',
+    );
     if (url == null) {
       throw BibleVersionDownloadException(
         BibleVersionDownloadErrorKind.network,
@@ -245,6 +249,10 @@ class BibleVersionRepository implements IBibleVersionRepository {
       version.name,
       version.disclaimer,
       version.remoteHash,
+    );
+    debugPrint(
+      '[BibleVersionRepository] downloadVersion(${version.dbFileName}) '
+      'complete — persisted hash=${version.remoteHash} to prefs',
     );
 
     if (contentLength != null && contentLength > 0) {

--- a/lib/utils/constants/bubble_constants.dart
+++ b/lib/utils/constants/bubble_constants.dart
@@ -21,6 +21,12 @@ class BubbleConstants {
   ); //azul vibrante para nuevo
   static const Color updatedFeatureColor = Color(0xFF2196F3);
   static const Color notificationColor = Color(0xFFFF5722);
+  // Orange for "content needs action" prompts — e.g. a downloaded Bible
+  // version whose remote file has since changed. Distinct from
+  // updatedFeatureColor (a neutral "feature was updated" announcement)
+  // and notificationColor (red-orange, generic alerts): this one signals
+  // "the content you have may be incorrect, please update it."
+  static const Color contentUpdateAvailableColor = Color(0xFFFF9800);
 
   // Posiciones para diferentes tipos de widgets
   static const double widgetBubbleTop = -6;

--- a/lib/widgets/bible/bible_chapter_grid_selector.dart
+++ b/lib/widgets/bible/bible_chapter_grid_selector.dart
@@ -152,13 +152,17 @@ class BibleChapterGridSelector extends StatelessWidget {
                 : null,
           ),
           child: Center(
-            child: Text(
-              chapterNumber.toString(),
-              style: textTheme.bodyMedium?.copyWith(
-                color:
-                    isSelected ? colorScheme.onPrimary : colorScheme.onSurface,
-                fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
-                fontSize: 18,
+            child: FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Text(
+                chapterNumber.toString(),
+                style: textTheme.bodyMedium?.copyWith(
+                  color: isSelected
+                      ? colorScheme.onPrimary
+                      : colorScheme.onSurface,
+                  fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+                  fontSize: 18,
+                ),
               ),
             ),
           ),

--- a/lib/widgets/bible/bible_reader_drawer.dart
+++ b/lib/widgets/bible/bible_reader_drawer.dart
@@ -115,13 +115,14 @@ class BibleReaderDrawer extends StatelessWidget {
                                     vertical: 2,
                                   ),
                                   decoration: BoxDecoration(
-                                    color: BubbleConstants.updatedFeatureColor,
+                                    color: BubbleConstants
+                                        .contentUpdateAvailableColor,
                                     borderRadius: BorderRadius.circular(
                                       BubbleConstants.widgetBubbleRadius,
                                     ),
                                   ),
                                   child: Text(
-                                    'bubble_constants.updated_feature'.tr(),
+                                    'bubble_constants.update_available'.tr(),
                                     style:
                                         BubbleConstants.widgetBubbleTextStyle,
                                   ),
@@ -146,13 +147,21 @@ class BibleReaderDrawer extends StatelessWidget {
                                 ),
                                 icon: Icon(
                                   Icons.system_update_alt_outlined,
-                                  color: BubbleConstants.updatedFeatureColor,
+                                  color: BubbleConstants
+                                      .contentUpdateAvailableColor,
                                 ),
                                 tooltip:
-                                    'bubble_constants.updated_feature'.tr(),
+                                    'bubble_constants.update_available'.tr(),
                                 onPressed: _isDownloading
                                     ? null
-                                    : () => onDownloadVersion(version),
+                                    : () {
+                                        debugPrint(
+                                          '[BibleReaderDrawer] update tapped '
+                                          'for ${version.dbFileName} — '
+                                          'remoteHash=${version.remoteHash}',
+                                        );
+                                        onDownloadVersion(version);
+                                      },
                               )
                             : null,
                         onTap: _isDownloading

--- a/lib/widgets/bible/bible_reader_drawer.dart
+++ b/lib/widgets/bible/bible_reader_drawer.dart
@@ -102,14 +102,42 @@ class BibleReaderDrawer extends StatelessWidget {
                               ? colorScheme.primary
                               : colorScheme.onSurface.withValues(alpha: 0.5),
                         ),
-                        title: Text(
-                          versionLabelBuilder(version),
-                          style: textTheme.bodyMedium?.copyWith(
-                            fontSize: 16,
-                            color: colorScheme.onSurface,
-                            fontWeight:
-                                isSelected ? FontWeight.w600 : FontWeight.w400,
-                          ),
+                        title: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            if (version.hasUpdate)
+                              Padding(
+                                padding: const EdgeInsets.only(bottom: 2),
+                                child: Container(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 8,
+                                    vertical: 2,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: BubbleConstants.updatedFeatureColor,
+                                    borderRadius: BorderRadius.circular(
+                                      BubbleConstants.widgetBubbleRadius,
+                                    ),
+                                  ),
+                                  child: Text(
+                                    'bubble_constants.updated_feature'.tr(),
+                                    style:
+                                        BubbleConstants.widgetBubbleTextStyle,
+                                  ),
+                                ),
+                              ),
+                            Text(
+                              versionLabelBuilder(version),
+                              style: textTheme.bodyMedium?.copyWith(
+                                fontSize: 16,
+                                color: colorScheme.onSurface,
+                                fontWeight: isSelected
+                                    ? FontWeight.w600
+                                    : FontWeight.w400,
+                              ),
+                            ),
+                          ],
                         ),
                         trailing: version.hasUpdate
                             ? IconButton(

--- a/lib/widgets/bible/bible_reader_drawer.dart
+++ b/lib/widgets/bible/bible_reader_drawer.dart
@@ -141,18 +141,12 @@ class BibleReaderDrawer extends StatelessWidget {
                           ],
                         ),
                         trailing: version.hasUpdate
-                            ? IconButton(
+                            ? InkWell(
                                 key: Key(
                                   'bible_reader_drawer_update_${version.dbFileName}',
                                 ),
-                                icon: Icon(
-                                  Icons.system_update_alt_outlined,
-                                  color: BubbleConstants
-                                      .contentUpdateAvailableColor,
-                                ),
-                                tooltip:
-                                    'bubble_constants.update_available'.tr(),
-                                onPressed: _isDownloading
+                                customBorder: const CircleBorder(),
+                                onTap: _isDownloading
                                     ? null
                                     : () {
                                         debugPrint(
@@ -162,6 +156,13 @@ class BibleReaderDrawer extends StatelessWidget {
                                         );
                                         onDownloadVersion(version);
                                       },
+                                child: _downloadTrailing(
+                                  colorScheme.copyWith(
+                                    primary: BubbleConstants
+                                        .contentUpdateAvailableColor,
+                                  ),
+                                  downloadStatuses[version.dbFileName],
+                                ),
                               )
                             : null,
                         onTap: _isDownloading

--- a/lib/widgets/bible/bible_reader_drawer.dart
+++ b/lib/widgets/bible/bible_reader_drawer.dart
@@ -111,6 +111,22 @@ class BibleReaderDrawer extends StatelessWidget {
                                 isSelected ? FontWeight.w600 : FontWeight.w400,
                           ),
                         ),
+                        trailing: version.hasUpdate
+                            ? IconButton(
+                                key: Key(
+                                  'bible_reader_drawer_update_${version.dbFileName}',
+                                ),
+                                icon: Icon(
+                                  Icons.system_update_alt_outlined,
+                                  color: BubbleConstants.updatedFeatureColor,
+                                ),
+                                tooltip:
+                                    'bubble_constants.updated_feature'.tr(),
+                                onPressed: _isDownloading
+                                    ? null
+                                    : () => onDownloadVersion(version),
+                              )
+                            : null,
                         onTap: _isDownloading
                             ? null
                             : () {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -906,10 +906,10 @@ packages:
     dependency: transitive
     description:
       name: in_app_purchase_storekit
-      sha256: "702a23c3d2ddc177b075d521d264900e82f01663881e4ef3ce17775de298c0e3"
+      sha256: "9602e249a0e30351f047d5715957f27709ed7b42f631fba8941dcad51489932a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.11"
+    version: "0.4.11+1"
   in_app_review:
     dependency: "direct main"
     description:

--- a/test/behavioral/bible_reader_user_behavior_test.dart
+++ b/test/behavioral/bible_reader_user_behavior_test.dart
@@ -396,6 +396,52 @@ void main() {
     );
 
     testWidgets(
+      'tapping the update action on an outdated downloaded version '
+      're-downloads it and clears the update badge',
+      (WidgetTester tester) async {
+        // GIVEN: the already-downloaded RVR1960 has a newer file available
+        // per the remote index (hasUpdate: true, matching dbFileName).
+        final outdatedRemoteEntry = BibleVersion(
+          name: 'Reina Valera 1960 (RVR1960)',
+          language: 'Español',
+          languageCode: 'es',
+          assetPath: '',
+          dbFileName: 'RVR1960_es.SQLite3',
+          isDownloaded: true,
+          remoteUrl: 'https://example.com/RVR1960_es.SQLite3.gz',
+          hasUpdate: true,
+          remoteHash: 'new-hash',
+          service: mockDbService,
+        );
+        fakeVersionRepository.versionsToReturn = [outdatedRemoteEntry];
+
+        await pumpBiblePage(tester);
+        await tester.pump(const Duration(milliseconds: 50));
+
+        // WHEN: the user opens the drawer
+        await tester.tap(find.byIcon(Icons.menu));
+        await tester.pumpAndSettle();
+        expect(find.byType(BibleReaderDrawer), findsOneWidget);
+
+        // THEN: the downloaded version shows an update action
+        final updateButtonFinder = find.byKey(
+          const Key('bible_reader_drawer_update_RVR1960_es.SQLite3'),
+        );
+        expect(updateButtonFinder, findsOneWidget);
+
+        // WHEN: the user taps it to re-download
+        await tester.tap(updateButtonFinder);
+        await tester.pumpAndSettle();
+
+        // THEN: the drawer closes and the version is re-initialized
+        expect(find.byType(BibleReaderDrawer), findsNothing);
+        verify(
+          () => mockDbService.initDb(any(), 'RVR1960_es.SQLite3'),
+        ).called(greaterThanOrEqualTo(2));
+      },
+    );
+
+    testWidgets(
       'BibleReaderPage requests remote versions for the content language, '
       'not the device locale',
       (WidgetTester tester) async {

--- a/test/behavioral/bible_reader_user_behavior_test.dart
+++ b/test/behavioral/bible_reader_user_behavior_test.dart
@@ -8,6 +8,7 @@ import 'package:devocional_nuevo/blocs/theme/theme_bloc.dart';
 import 'package:devocional_nuevo/blocs/theme/theme_state.dart';
 import 'package:devocional_nuevo/pages/bible_reader_page.dart';
 import 'package:devocional_nuevo/repositories/i_bible_notes_repository.dart';
+import 'package:devocional_nuevo/repositories/bible_version_repository.dart';
 import 'package:devocional_nuevo/repositories/i_bible_version_repository.dart';
 import 'package:devocional_nuevo/models/bible_note.dart';
 import 'package:devocional_nuevo/widgets/bible/bible_note_modal.dart';
@@ -43,6 +44,16 @@ class _FakeBibleVersionRepository implements IBibleVersionRepository {
     BibleVersion version, {
     void Function(double? progress)? onProgress,
   }) async {
+    // Mirrors BibleVersionRepository.downloadVersion's real guard — a
+    // version passed in with no remoteUrl (e.g. because a caller spliced
+    // together a BibleVersion missing that field) must fail the same way
+    // production does, not silently "succeed" and mask the bug.
+    if (version.remoteUrl == null) {
+      throw BibleVersionDownloadException(
+        BibleVersionDownloadErrorKind.network,
+        'Version has no remoteUrl',
+      );
+    }
     onProgress?.call(1.0);
   }
 }

--- a/test/integration/bible_version_index_live_test.dart
+++ b/test/integration/bible_version_index_live_test.dart
@@ -1,0 +1,41 @@
+@Tags(['integration'])
+library;
+
+import 'dart:convert';
+
+import 'package:devocional_nuevo/models/remote_bible_index.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+/// Hits the real bible_versions index.json on GitHub to confirm
+/// RemoteBibleIndex still parses its production shape — including the
+/// per-version "hash" fingerprint field added for update detection — since
+/// the unit tests in bible_version_repository_test.dart use hand-built
+/// minimal JSON fixtures that wouldn't catch schema drift in the real file.
+void main() {
+  test('parses the real production index.json and every version has a hash',
+      () async {
+    final response = await http.get(
+      Uri.parse(
+        'https://raw.githubusercontent.com/develop4God/bible_versions/main/index.json',
+      ),
+    );
+    expect(response.statusCode, 200);
+
+    final index = RemoteBibleIndex.fromJson(
+      jsonDecode(response.body) as Map<String, dynamic>,
+    );
+
+    expect(index.languages, isNotEmpty);
+    for (final language in index.languages.values) {
+      for (final entry in language.versions.values) {
+        expect(
+          entry.hash,
+          isNotNull,
+          reason: '${entry.file} is missing a hash in the live index',
+        );
+        expect(entry.hash!.length, 16);
+      }
+    }
+  });
+}

--- a/test/unit/pages/bible_reader_page_test.dart
+++ b/test/unit/pages/bible_reader_page_test.dart
@@ -626,21 +626,37 @@ void main() {
         controller.dispose();
       });
 
-      test('Switching to same version is a no-op', () async {
-        final rvr = _makeVersion(name: 'RVR1960');
-        final controller = _makeController(versions: [rvr]);
-        await controller.initialize('es');
+      test(
+        'Switching to same version refreshes metadata without reloading '
+        'reading state',
+        () async {
+          final rvr = _makeVersion(name: 'RVR1960');
+          final controller = _makeController(versions: [rvr]);
+          await controller.initialize('es');
 
-        final statesBefore = controller.state;
-        await controller.switchVersion(rvr);
+          final stateBefore = controller.state;
+          await controller.switchVersion(rvr);
 
-        expect(
-          controller.state,
-          same(statesBefore),
-          reason: 'Switching to current version should not emit new state',
-        );
-        controller.dispose();
-      });
+          expect(
+            controller.state.selectedVersion,
+            same(rvr),
+            reason: 'Re-selecting the same dbFileName should adopt the '
+                'passed-in version instance (metadata refresh)',
+          );
+          expect(
+            controller.state.selectedBookNumber,
+            stateBefore.selectedBookNumber,
+            reason: 'Re-selecting the current version must not reset '
+                'reading position',
+          );
+          expect(
+            controller.state.selectedChapter,
+            stateBefore.selectedChapter,
+          );
+          expect(controller.state.isLoading, isFalse);
+          controller.dispose();
+        },
+      );
 
       test('isLoading is false after version switch completes', () async {
         final rvr = _makeVersion(name: 'RVR1960');
@@ -693,11 +709,14 @@ void main() {
       );
 
       test(
-        'Different name, same dbFileName — controller treats them as same',
+        'Different name, same dbFileName — controller treats them as same '
+        'without reloading, but refreshes the listed metadata',
         () async {
           // Two version objects have different display names but identical
-          // dbFileName. The controller should consider them the same version
-          // and skip the switch entirely.
+          // dbFileName. The controller must use dbFileName (not name) as the
+          // identity key, so it should not re-initialize the DB or reset
+          // reading position — but it still adopts versionB's metadata,
+          // e.g. for a redownload that updates hasUpdate/remoteHash.
           final versionA = _makeVersion(
             name: 'RVR1960',
             dbFileName: 'shared.db',
@@ -710,12 +729,16 @@ void main() {
           await controller.switchVersion(versionB);
 
           expect(
-            controller.state,
-            same(stateBefore),
-            reason:
-                'Versions with the same dbFileName must be treated as identical '
-                '— switchVersion should be a no-op',
+            controller.state.selectedVersion,
+            same(versionB),
+            reason: 'dbFileName match should adopt the new version instance',
           );
+          expect(
+            controller.state.selectedBookNumber,
+            stateBefore.selectedBookNumber,
+            reason: 'Same dbFileName must not reset reading position',
+          );
+          expect(controller.state.isLoading, isFalse);
           controller.dispose();
         },
       );

--- a/test/unit/repositories/bible_version_repository_test.dart
+++ b/test/unit/repositories/bible_version_repository_test.dart
@@ -281,6 +281,120 @@ void main() {
       final result = await repository.fetchRemoteVersions('en');
       expect(result, isEmpty); // en is fully bundled per fullIndex
     });
+
+    test(
+        'surfaces an already-downloaded remote version with hasUpdate when '
+        'the index hash differs from the stored hash', () async {
+      final file = File('${Directory.systemTemp.path}/NGU_de.SQLite3');
+      addTearDown(() {
+        if (file.existsSync()) file.deleteSync();
+      });
+      await file.writeAsBytes([1, 2, 3]);
+
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        'bible_remote_version_names',
+        jsonEncode({
+          'NGU_de.SQLite3': {'name': 'Neue Genfer Übersetzung', 'hash': 'old'},
+        }),
+      );
+
+      stubIndexResponse(jsonEncode({
+        'languages': {
+          'de': {
+            'versions': {
+              'NGU': {
+                'name': 'Neue Genfer Übersetzung',
+                'file': 'NGU_de.SQLite3.gz',
+                'url': 'https://raw.githubusercontent.com/develop4God/'
+                    'bible_versions/main/de/NGU_de.SQLite3.gz',
+                'hash': 'new',
+              },
+            },
+          },
+        },
+      }));
+
+      final result = await repository.fetchRemoteVersions('de');
+
+      expect(result, hasLength(1));
+      expect(result.first.dbFileName, 'NGU_de.SQLite3');
+      expect(result.first.hasUpdate, isTrue);
+      expect(result.first.isDownloaded, isTrue);
+    });
+
+    test(
+        'omits an already-downloaded remote version when the index hash '
+        'matches the stored hash', () async {
+      final file = File('${Directory.systemTemp.path}/NGU_de.SQLite3');
+      addTearDown(() {
+        if (file.existsSync()) file.deleteSync();
+      });
+      await file.writeAsBytes([1, 2, 3]);
+
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        'bible_remote_version_names',
+        jsonEncode({
+          'NGU_de.SQLite3': {'name': 'Neue Genfer Übersetzung', 'hash': 'same'},
+        }),
+      );
+
+      stubIndexResponse(jsonEncode({
+        'languages': {
+          'de': {
+            'versions': {
+              'NGU': {
+                'name': 'Neue Genfer Übersetzung',
+                'file': 'NGU_de.SQLite3.gz',
+                'url': 'https://raw.githubusercontent.com/develop4God/'
+                    'bible_versions/main/de/NGU_de.SQLite3.gz',
+                'hash': 'same',
+              },
+            },
+          },
+        },
+      }));
+
+      final result = await repository.fetchRemoteVersions('de');
+
+      expect(result, isEmpty);
+    });
+
+    test(
+        'omits an already-downloaded remote version when neither stored '
+        'nor index hash is present (pre-fingerprint data)', () async {
+      final file = File('${Directory.systemTemp.path}/NGU_de.SQLite3');
+      addTearDown(() {
+        if (file.existsSync()) file.deleteSync();
+      });
+      await file.writeAsBytes([1, 2, 3]);
+
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        'bible_remote_version_names',
+        jsonEncode({'NGU_de.SQLite3': 'Neue Genfer Übersetzung'}),
+      );
+
+      stubIndexResponse(jsonEncode({
+        'languages': {
+          'de': {
+            'versions': {
+              'NGU': {
+                'name': 'Neue Genfer Übersetzung',
+                'file': 'NGU_de.SQLite3.gz',
+                'url': 'https://raw.githubusercontent.com/develop4God/'
+                    'bible_versions/main/de/NGU_de.SQLite3.gz',
+              },
+            },
+          },
+        },
+      }));
+
+      final result = await repository.fetchRemoteVersions('de');
+
+      expect(result, isEmpty);
+    });
   });
 
   group('downloadVersion', () {
@@ -420,6 +534,44 @@ void main() {
 
       final installedFile =
           File('${Directory.systemTemp.path}/DISCLAIM_xx.SQLite3');
+      if (installedFile.existsSync()) installedFile.deleteSync();
+    });
+
+    test('persists the remote hash alongside the name on successful download',
+        () async {
+      final gzipBytes = _validGzipBytes();
+      when(() => mockHttpClient.send(any())).thenAnswer(
+        (_) async => http.StreamedResponse(
+          Stream.value(gzipBytes),
+          200,
+          contentLength: gzipBytes.length,
+        ),
+      );
+
+      final version = BibleVersion(
+        name: 'Neue Genfer Übersetzung',
+        language: 'Deutsch',
+        languageCode: 'de',
+        assetPath: '',
+        dbFileName: 'HASH_xx.SQLite3',
+        isDownloaded: false,
+        remoteUrl: 'https://example.com/ngu.gz',
+        remoteHash: 'abc123def456',
+      );
+
+      await repository.downloadVersion(version);
+
+      final prefs = await SharedPreferences.getInstance();
+      final stored = jsonDecode(prefs.getString('bible_remote_version_names')!)
+          as Map<String, dynamic>;
+
+      expect(
+        stored['HASH_xx.SQLite3'],
+        {'name': 'Neue Genfer Übersetzung', 'hash': 'abc123def456'},
+      );
+
+      final installedFile =
+          File('${Directory.systemTemp.path}/HASH_xx.SQLite3');
       if (installedFile.existsSync()) installedFile.deleteSync();
     });
   });

--- a/test/unit/repositories/bible_version_repository_test.dart
+++ b/test/unit/repositories/bible_version_repository_test.dart
@@ -395,6 +395,55 @@ void main() {
 
       expect(result, isEmpty);
     });
+
+    test(
+        'surfaces hasUpdate for a legacy download (no stored hash) against '
+        'a non-null index hash, rather than silently adopting the index '
+        'hash as an unverified baseline — the index may have already '
+        'moved past what is actually on disk, so a null stored hash must '
+        'never be assumed safe', () async {
+      final file = File('${Directory.systemTemp.path}/NGU_de.SQLite3');
+      addTearDown(() {
+        if (file.existsSync()) file.deleteSync();
+      });
+      await file.writeAsBytes([1, 2, 3]);
+
+      final prefs = await SharedPreferences.getInstance();
+      // Legacy plain-string entry — predates the hash field entirely, so
+      // there's nothing to compare against yet.
+      await prefs.setString(
+        'bible_remote_version_names',
+        jsonEncode({'NGU_de.SQLite3': 'Neue Genfer Übersetzung'}),
+      );
+
+      stubIndexResponse(jsonEncode({
+        'languages': {
+          'de': {
+            'versions': {
+              'NGU': {
+                'name': 'Neue Genfer Übersetzung',
+                'file': 'NGU_de.SQLite3.gz',
+                'url': 'https://raw.githubusercontent.com/develop4God/'
+                    'bible_versions/main/de/NGU_de.SQLite3.gz',
+                'hash': 'current-index-hash',
+              },
+            },
+          },
+        },
+      }));
+
+      final result = await repository.fetchRemoteVersions('de');
+
+      expect(result, hasLength(1));
+      expect(result.first.dbFileName, 'NGU_de.SQLite3');
+      expect(result.first.hasUpdate, isTrue);
+
+      // No silent write to prefs — nothing is backfilled behind the
+      // user's back; the stored entry is untouched until they redownload.
+      final stored = jsonDecode(prefs.getString('bible_remote_version_names')!)
+          as Map<String, dynamic>;
+      expect(stored['NGU_de.SQLite3'], 'Neue Genfer Übersetzung');
+    });
   });
 
   group('downloadVersion', () {

--- a/test/unit/widgets/bible_chapter_grid_selector_test.dart
+++ b/test/unit/widgets/bible_chapter_grid_selector_test.dart
@@ -106,6 +106,64 @@ void main() {
       expect(builder.estimatedChildCount, equals(totalChapters));
     });
 
+    testWidgets(
+      'Should render 3-digit chapter numbers without overflow on small screens (Psalms 150)',
+      (WidgetTester tester) async {
+        tester.view.physicalSize = const Size(320, 480);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: BibleChapterGridSelector(
+                totalChapters: 150,
+                selectedChapter: 1,
+                bookName: 'Psalms',
+                onChapterSelected: (chapter) {},
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+
+        // Scroll to reveal 3-digit chapter numbers (100+).
+        await tester.dragUntilVisible(
+          find.text('100'),
+          find.byType(GridView),
+          const Offset(0, -100),
+        );
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+
+        // The rendered text for a 3-digit chapter must not be clipped: its
+        // laid-out width must fit within the cell that contains it.
+        final textFinder = find.text('100');
+        expect(textFinder, findsOneWidget);
+
+        final textWidget = tester.widget<Text>(textFinder);
+        final renderObject = tester.renderObject(textFinder) as RenderBox;
+
+        final painter = TextPainter(
+          text: TextSpan(text: textWidget.data, style: textWidget.style),
+          textDirection: TextDirection.ltr,
+        )..layout();
+
+        expect(
+          painter.width,
+          lessThanOrEqualTo(renderObject.size.width),
+          reason: 'Chapter number "100" text width (${painter.width}) '
+              'exceeds its cell width (${renderObject.size.width}) on a '
+              'small screen — the digits will visually clip/overlap.',
+        );
+      },
+    );
+
     testWidgets('Should call callback when chapter is tapped', (
       WidgetTester tester,
     ) async {

--- a/test/unit/widgets/bible_reader_drawer_test.dart
+++ b/test/unit/widgets/bible_reader_drawer_test.dart
@@ -312,7 +312,7 @@ void main() {
     // A bare icon with only a long-press tooltip reads as an unlabeled
     // decoration at a glance — the "Updated" chip must be visibly present
     // as text, not only discoverable via tooltip.
-    expect(find.text('bubble_constants.updated_feature'), findsOneWidget);
+    expect(find.text('bubble_constants.update_available'), findsOneWidget);
 
     await tester.tap(updateButton);
     await tester.pumpAndSettle();

--- a/test/unit/widgets/bible_reader_drawer_test.dart
+++ b/test/unit/widgets/bible_reader_drawer_test.dart
@@ -322,6 +322,26 @@ void main() {
     expect(find.byType(Drawer), findsOneWidget);
   });
 
+  testWidgets(
+      'shows a progress ring on the update action while a redownload is '
+      'in flight, matching the same trailing treatment as a first-time '
+      'download', (tester) async {
+    final versionA = _version('A_xx.SQLite3', name: 'Version A');
+    final outdated = _version('B_xx.SQLite3', name: 'Version B')
+        .copyWith(hasUpdate: true, isDownloaded: true);
+
+    await pumpDrawer(
+      tester,
+      versions: [versionA, outdated],
+      selectedVersion: versionA,
+      downloadStatuses: const {
+        'B_xx.SQLite3': VersionDownloadStatus(progress: 0.5),
+      },
+    );
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
   testWidgets('does not show an update action for a version without hasUpdate',
       (tester) async {
     final versionA = _version('A_xx.SQLite3', name: 'Version A');

--- a/test/unit/widgets/bible_reader_drawer_test.dart
+++ b/test/unit/widgets/bible_reader_drawer_test.dart
@@ -286,4 +286,51 @@ void main() {
 
     expect(downloadRequested, downloadable);
   });
+
+  testWidgets(
+      'shows an update action for a downloaded version with hasUpdate; '
+      'tapping it invokes the download callback without changing selection',
+      (tester) async {
+    final versionA = _version('A_xx.SQLite3', name: 'Version A');
+    final outdated = _version('B_xx.SQLite3', name: 'Version B')
+        .copyWith(hasUpdate: true, isDownloaded: true);
+    BibleVersion? selected;
+    BibleVersion? downloadRequested;
+
+    await pumpDrawer(
+      tester,
+      versions: [versionA, outdated],
+      selectedVersion: versionA,
+      onVersionSelected: (v) => selected = v,
+      onDownloadVersion: (v) => downloadRequested = v,
+    );
+
+    final updateButton = find.byKey(
+      const Key('bible_reader_drawer_update_B_xx.SQLite3'),
+    );
+    expect(updateButton, findsOneWidget);
+
+    await tester.tap(updateButton);
+    await tester.pumpAndSettle();
+
+    expect(downloadRequested, outdated);
+    expect(selected, isNull);
+    expect(find.byType(Drawer), findsOneWidget);
+  });
+
+  testWidgets('does not show an update action for a version without hasUpdate',
+      (tester) async {
+    final versionA = _version('A_xx.SQLite3', name: 'Version A');
+
+    await pumpDrawer(
+      tester,
+      versions: [versionA],
+      selectedVersion: versionA,
+    );
+
+    expect(
+      find.byKey(const Key('bible_reader_drawer_update_A_xx.SQLite3')),
+      findsNothing,
+    );
+  });
 }

--- a/test/unit/widgets/bible_reader_drawer_test.dart
+++ b/test/unit/widgets/bible_reader_drawer_test.dart
@@ -309,6 +309,10 @@ void main() {
       const Key('bible_reader_drawer_update_B_xx.SQLite3'),
     );
     expect(updateButton, findsOneWidget);
+    // A bare icon with only a long-press tooltip reads as an unlabeled
+    // decoration at a glance — the "Updated" chip must be visibly present
+    // as text, not only discoverable via tooltip.
+    expect(find.text('bubble_constants.updated_feature'), findsOneWidget);
 
     await tester.tap(updateButton);
     await tester.pumpAndSettle();


### PR DESCRIPTION
Implement update detection for downloaded Bible versions by introducing a remote hash tracking mechanism. This allows the application to identify when newer content is available and update the UI accordingly. Clear stale metadata upon re-download to ensure accurate versioning and update badges.