### PR TITLE
fix: skip PR comment job for Dependabot PRs

### DIFF
--- a/.github/workflows/🚀Flutter CI.yml
+++ b/.github/workflows/🚀Flutter CI.yml
@@ -417,7 +417,7 @@ jobs:
     name: 💬 PR Comment
     runs-on: ubuntu-latest
     needs: [ gate, analyze, test ]
-    if: github.event_name == 'pull_request' && needs.gate.result == 'success'
+    if: github.event_name == 'pull_request' && needs.gate.result == 'success' && github.actor != 'dependabot[bot]'
     steps:
       - name: 📥 Download coverage
         uses: actions/download-artifact@v6.0.0


### PR DESCRIPTION
## Summary
- GitHub gives `dependabot[bot]`-triggered `pull_request` runs a read-only `GITHUB_TOKEN` as a hard platform policy — not configurable via any repo setting (confirmed repo's own `default_workflow_permissions` is already `write`)
- The `💬 PR Comment` job's `createComment()` call always fails on Dependabot PRs with "Resource not accessible by integration" (see #299)
- Skip the job entirely when `github.actor == 'dependabot[bot]'` instead of letting it fail every time

## Not a regression
Actual code checks (Static Analysis, Testing, Security Scan, CI Gate, Trivy) already pass fine on Dependabot PRs — only the cosmetic comment step was failing.

## Test plan
- [x] YAML validated
- [x] Workflow lint passed via pre-commit hook
- [ ] Confirm on next Dependabot PR that the comment job is skipped (green) instead of failing